### PR TITLE
feat: add svc-arbi-dash worker and dashboard

### DIFF
--- a/svc-arbi-dash/.eslintrc.cjs
+++ b/svc-arbi-dash/.eslintrc.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname,
+    ecmaVersion: 2021,
+    sourceType: 'module'
+  },
+  env: {
+    browser: true,
+    es2021: true,
+    worker: true
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended'
+  ],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
+  }
+};

--- a/svc-arbi-dash/README.md
+++ b/svc-arbi-dash/README.md
@@ -1,0 +1,79 @@
+# svc-arbi-dash
+
+svc-arbi-dash is a Cloudflare Worker + React (Vite + Tailwind) dashboard for monitoring cross-exchange arbitrage between Luno and Kraken, capturing user trades, and generating UK HMRC capital gains reports. The service shares market samples from the `svc-arbi-ingestor` Durable Object and adds its own `TradeLedger` Durable Object for trade history and tax computation.
+
+```
+repo
+└── svc-arbi-dash
+    ├── app/                # React SPA (Vite + Tailwind)
+    ├── worker/             # Cloudflare Worker + TradeLedger DO
+    ├── tests/              # Vitest unit tests (calc + HMRC)
+    ├── wrangler.json       # Worker configuration
+    ├── package.json        # root scripts & dependencies
+    └── README.md           # this file
+```
+
+## Architecture
+
+* **Cloudflare Worker (`worker/src/index.ts`)** – handles all routing, enforces `?auth=<token>` security, proxies `/data` to the shared `TradeStore` DO, forwards `/trades*` and `/tax/*` to the local `TradeLedger`, and serves the SPA at `/dash`.
+* **TradeLedger Durable Object** – persists user trades, maintains composite indexes, derives GBP valuations (including Frankfurter lookups when only ZAR is provided), enforces locking, and exposes HMRC endpoints that apply same-day, 30-day, and Section 104 share-matching rules.
+* **React SPA (`app/`)** – dashboard with per-asset and combined uPlot charts, recent data tables, calculators, FX converters, position sizer, trade entry/editor, CSV export, tax reports, and a diagnostics-aware health strip. User preferences persist via `useLocalSettings`.
+* **Data sources** – market data from `svc-arbi-ingestor`'s Durable Object, and live Frankfurter quotes (client for converters, server for missing FX when valuing trades).
+
+## Prerequisites
+
+* Node.js 20.x
+* npm
+* Cloudflare Wrangler (installed via `npm install`)
+
+## Setup
+
+```bash
+cd svc-arbi-dash
+npm install
+# configure Cloudflare secret (only once per environment)
+npx wrangler secret put AUTH_TOKEN
+```
+
+## Local development
+
+1. Build the client bundle once so Wrangler can serve the assets:
+   ```bash
+   npm run build
+   ```
+
+2. In a separate terminal, run the Worker in dev mode:
+   ```bash
+   npm run dev
+   ```
+   Visit `http://localhost:8787/dash?auth=<your-token>`.
+
+3. The dashboard auto-refreshes every minute, defaulting to a 24h history window. Use the Settings drawer to adjust history, fees, balances, slippage caps, and persistence profiles.
+
+## Testing
+
+Vitest covers calculator helpers and HMRC share-matching logic.
+
+```bash
+npm test
+```
+
+## Build & Deploy
+
+* Build: `npm run build` (runs `vite build` and `wrangler build`).
+* Deploy: `npm run deploy` (Cloudflare Wrangler deploy).
+
+## Worker configuration
+
+`wrangler.json` binds the shared `TRADE_STORE` DO (from `svc-arbi-ingestor`) and the local `TRADE_LEDGER` DO, with migrations for the ledger only. Static assets are served from `app/dist` via Wrangler's assets binding. All routes enforce `?auth=<token>` and return 404 if missing or invalid.
+
+## Features
+
+* **Dashboard** – header tiles with current arbitrage stats, health strip diagnostics, per-asset and combined charts (nominal vs. effective arbitrage, Luno/Kraken legs), recent sample table with filters and CSV export, calculators, FX converters (60s cache), position sizer, and explain-spike modal.
+* **Trades** – Durable Object-backed trade CRUD with locking, GBP valuation enforcement (Frankfurter fallback), CSV export, and multi-locking controls. Form auto-prefills FX when only ZAR price is supplied.
+* **Tax reports** – HMRC same-day → 30-day → Section 104 matching, disposal breakdowns, totals by asset, Section 104 pool balances, and CSV exports. Preview endpoints support arbitrary date windows.
+* **Security** – `AUTH_TOKEN` secret stored via Wrangler. Every route requires the query param and emits 404 otherwise. No secrets are committed.
+
+## Data privacy & disclaimer
+
+All trade data stays within the configured Cloudflare account in the `TradeLedger` Durable Object. Frankfurter requests contain only FX symbols; no personal data leaves the Worker. HMRC calculations are deterministic but provided for guidance only – **this tool is not tax advice**.

--- a/svc-arbi-dash/app/index.html
+++ b/svc-arbi-dash/app/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/dash/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>svc-arbi-dash</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/dash/src/main.tsx"></script>
+  </body>
+</html>

--- a/svc-arbi-dash/app/postcss.config.cjs
+++ b/svc-arbi-dash/app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/svc-arbi-dash/app/src/App.tsx
+++ b/svc-arbi-dash/app/src/App.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import 'uplot/dist/uPlot.min.css';
+import HeaderTiles from './components/HeaderTiles';
+import HealthStrip from './components/HealthStrip';
+import AssetChart from './components/AssetChart';
+import CombinedChart from './components/CombinedChart';
+import RecentTable from './components/RecentTable';
+import Calculators from './components/Calculators';
+import PositionSizer from './components/PositionSizer';
+import SettingsDrawer from './components/SettingsDrawer';
+import ExplainSpikeModal from './components/ExplainSpikeModal';
+import TradesForm from './components/TradesForm';
+import TradesTable from './components/TradesTable';
+import TaxReports from './components/TaxReports';
+import { useLocalSettings } from './hooks/useLocalSettings';
+import { useDataWindow } from './hooks/useDataWindow';
+import { useFrankfurter } from './hooks/useFrankfurter';
+import { useTradesApi } from './hooks/useTradesApi';
+import { Sample, Trade } from './lib/types';
+
+const ASSETS = ['ETH', 'BTC', 'USDT'] as const;
+
+type TabKey = 'dashboard' | 'trades' | 'tax';
+
+function useAuthToken(): string {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('auth') ?? '';
+}
+
+function App() {
+  const authToken = useAuthToken();
+  const settingsController = useLocalSettings();
+  const { settings } = settingsController;
+  const dataWindow = useDataWindow({ authToken, historyHours: settings.historyHours, autoRefreshMs: settings.autoRefreshMs });
+  const frankfurter = useFrankfurter();
+  const tradesApi = useTradesApi(authToken);
+  const [activeTab, setActiveTab] = useState<TabKey>('dashboard');
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [explain, setExplain] = useState<{ asset: (typeof ASSETS)[number] | null; sample: Sample | null }>({ asset: null, sample: null });
+  const [editingTrade, setEditingTrade] = useState<Trade | null>(null);
+
+  const latestSample = dataWindow.samples.length ? dataWindow.samples[dataWindow.samples.length - 1] : null;
+
+  const handleTradeSubmit = async (payload: Partial<Trade> & { id?: string }) => {
+    try {
+      if (payload.id) {
+        await tradesApi.update(payload as Trade);
+        setEditingTrade(null);
+      } else {
+        await tradesApi.create(payload as Trade);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const explainClose = () => setExplain({ asset: null, sample: null });
+
+  const dashboardContent = (
+    <div className="space-y-6">
+      <HeaderTiles
+        sample={latestSample}
+        settings={settings}
+        quotes={frankfurter.quotes}
+        onSettingsOpen={() => setSettingsOpen(true)}
+      />
+      <HealthStrip
+        samples={dataWindow.samples}
+        frankfurterError={frankfurter.error}
+        dataError={dataWindow.error}
+        tradeError={tradesApi.error}
+      />
+      <CombinedChart samples={dataWindow.samples} settings={settings} onExplain={setExplain} />
+      <div className="space-y-4">
+        {ASSETS.map((asset) => (
+          <AssetChart key={asset} asset={asset} samples={dataWindow.samples} settings={settings} onExplain={setExplain} />
+        ))}
+      </div>
+      <RecentTable samples={dataWindow.samples} settings={settings} />
+      <div className="grid gap-4 md:grid-cols-2">
+        <Calculators quotes={frankfurter.quotes} />
+        <PositionSizer sample={latestSample} settings={settings} />
+      </div>
+    </div>
+  );
+
+  const tradesContent = (
+    <div className="space-y-4">
+      <TradesForm onSubmit={handleTradeSubmit} editing={editingTrade} onCancelEdit={() => setEditingTrade(null)} />
+      <TradesTable api={tradesApi} onEdit={(trade) => setEditingTrade(trade)} />
+    </div>
+  );
+
+  const taxContent = <TaxReports authToken={authToken} />;
+
+  if (!authToken) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-slate-950 text-slate-100">
+        <div className="max-w-md text-center space-y-3">
+          <h1 className="text-2xl font-semibold">svc-arbi-dash</h1>
+          <p className="text-sm text-slate-400">Missing auth token. Append ?auth=&lt;token&gt; to the URL.</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-panel">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Arbitrage dashboard</h1>
+            <p className="text-xs text-slate-400">Data refreshes every {settings.autoRefreshMs / 1000} seconds.</p>
+          </div>
+          <nav className="flex items-center gap-3 text-sm">
+            <button
+              className={activeTab === 'dashboard' ? 'text-sky-400' : 'text-slate-400 hover:text-sky-300'}
+              onClick={() => setActiveTab('dashboard')}
+            >
+              Dashboard
+            </button>
+            <button
+              className={activeTab === 'trades' ? 'text-sky-400' : 'text-slate-400 hover:text-sky-300'}
+              onClick={() => setActiveTab('trades')}
+            >
+              Trades
+            </button>
+            <button
+              className={activeTab === 'tax' ? 'text-sky-400' : 'text-slate-400 hover:text-sky-300'}
+              onClick={() => setActiveTab('tax')}
+            >
+              Tax Reports
+            </button>
+            <button onClick={() => setSettingsOpen(true)} className="bg-slate-700 hover:bg-slate-600 px-3 py-1 rounded">
+              Settings
+            </button>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-6xl space-y-6 px-6 py-6">
+        {activeTab === 'dashboard' ? dashboardContent : null}
+        {activeTab === 'trades' ? tradesContent : null}
+        {activeTab === 'tax' ? taxContent : null}
+      </main>
+      <SettingsDrawer controller={settingsController} open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <ExplainSpikeModal open={Boolean(explain.asset)} asset={explain.asset} sample={explain.sample} settings={settings} onClose={explainClose} />
+    </div>
+  );
+}
+
+export default App;

--- a/svc-arbi-dash/app/src/components/AssetChart.tsx
+++ b/svc-arbi-dash/app/src/components/AssetChart.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import uPlot from 'uplot';
+import { effectiveArbPercentage, withdrawalAmortizationPct } from '../lib/calc';
+import { Sample, AssetSymbol } from '../lib/types';
+import { LocalSettings } from '../hooks/useLocalSettings';
+
+const AGG_OPTIONS = [
+  { label: '1m', minutes: 1 },
+  { label: '5m', minutes: 5 },
+  { label: '15m', minutes: 15 },
+  { label: '1h', minutes: 60 }
+];
+
+type AssetChartProps = {
+  asset: AssetSymbol;
+  samples: Sample[];
+  settings: LocalSettings;
+  onExplain: (payload: { asset: AssetSymbol; sample: Sample }) => void;
+};
+
+function aggregate(samples: Sample[], minutes: number): Sample[] {
+  if (minutes <= 1) {
+    return samples;
+  }
+  const bucketMs = minutes * 60 * 1000;
+  const buckets = new Map<number, Sample>();
+  for (const sample of samples) {
+    const bucket = Math.floor(sample.ts / bucketMs) * bucketMs;
+    const existing = buckets.get(bucket);
+    if (!existing || sample.ts > existing.ts) {
+      buckets.set(bucket, sample);
+    }
+  }
+  return Array.from(buckets.values()).sort((a, b) => a.ts - b.ts);
+}
+
+function computeEffective(sample: Sample, asset: AssetSymbol, settings: LocalSettings) {
+  const snapshot = sample[asset];
+  const slippage = settings.slippageCaps[asset];
+  const fees = {
+    kraken: settings.fees.kraken[asset].taker,
+    luno: settings.fees.luno[asset].taker
+  };
+  const withdrawalKraken = settings.withdrawalFees[asset].kraken;
+  const withdrawalLuno = settings.withdrawalFees[asset].luno;
+  const notionalGBP = settings.balances.krakenGBP;
+  const notionalGBP2 = settings.balances.lunoZAR / sample.fx_gbp_zar;
+  const withdrawalKrakenPct = settings.withdrawalAmortization && snapshot.krakenAskGBP
+    ? withdrawalAmortizationPct(withdrawalKraken, snapshot.krakenAskGBP, notionalGBP)
+    : 0;
+  const withdrawalLunoPct = settings.withdrawalAmortization && snapshot.krakenBidGBP
+    ? withdrawalAmortizationPct(withdrawalLuno, snapshot.krakenBidGBP, notionalGBP2)
+    : 0;
+  const kToLNominal = snapshot.arb_buyKraken_sellLuno_pct ?? null;
+  const lToKNominal = snapshot.arb_buyLuno_sellKraken_pct ?? null;
+  const kToL =
+    kToLNominal === null
+      ? null
+      : effectiveArbPercentage({
+          nominalPct: kToLNominal,
+          legs: [
+            { feePct: fees.kraken, slippagePct: slippage },
+            { feePct: fees.luno, slippagePct: slippage }
+          ],
+          withdrawalPct: withdrawalKrakenPct
+        });
+  const lToK =
+    lToKNominal === null
+      ? null
+      : effectiveArbPercentage({
+          nominalPct: lToKNominal,
+          legs: [
+            { feePct: fees.luno, slippagePct: slippage },
+            { feePct: fees.kraken, slippagePct: slippage }
+          ],
+          withdrawalPct: withdrawalLunoPct
+        });
+  return { kToL, lToK, kToLNominal, lToKNominal };
+}
+
+export function AssetChart({ asset, samples, settings, onExplain }: AssetChartProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const plotRef = useRef<uPlot | null>(null);
+  const [agg, setAgg] = useState(AGG_OPTIONS[1]);
+
+  const data = useMemo(() => {
+    const aggregated = aggregate(samples, agg.minutes);
+    const times = aggregated.map((s) => s.ts / 1000);
+    const lunoBid = aggregated.map((s) => s[asset].lunoBestBidZAR ?? null);
+    const lunoAsk = aggregated.map((s) => s[asset].lunoBestAskZAR ?? null);
+    const krakenBidGBP = aggregated.map((s) => s[asset].krakenBidGBP ?? null);
+    const krakenAskGBP = aggregated.map((s) => s[asset].krakenAskGBP ?? null);
+    const krakenBidZAR = aggregated.map((s) => s[asset].krakenBidZAR ?? null);
+    const krakenAskZAR = aggregated.map((s) => s[asset].krakenAskZAR ?? null);
+    const effectiveK = aggregated.map((s) => computeEffective(s, asset, settings).kToL);
+    const effectiveL = aggregated.map((s) => computeEffective(s, asset, settings).lToK);
+    const nominalK = aggregated.map((s) => computeEffective(s, asset, settings).kToLNominal);
+    const nominalL = aggregated.map((s) => computeEffective(s, asset, settings).lToKNominal);
+    return {
+      aggregated,
+      series: [times, lunoBid, lunoAsk, krakenBidGBP, krakenAskGBP, krakenBidZAR, krakenAskZAR, nominalK, nominalL, effectiveK, effectiveL]
+    };
+  }, [samples, agg, asset, settings]);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+    const options: uPlot.Options = {
+      width: containerRef.current.clientWidth,
+      height: 320,
+      title: `${asset} orderbook & arbitrage`,
+      tzDate: (ts) => uPlot.tzDate(new Date(ts * 1000), 'Europe/London'),
+      scales: {
+        x: { time: true },
+        price: { auto: true },
+        percent: { auto: true }
+      },
+      series: [
+        {},
+        { label: 'Luno Bid (ZAR)', scale: 'price', stroke: '#38bdf8' },
+        { label: 'Luno Ask (ZAR)', scale: 'price', stroke: '#0ea5e9' },
+        { label: 'Kraken Bid (GBP)', scale: 'price', stroke: '#f97316' },
+        { label: 'Kraken Ask (GBP)', scale: 'price', stroke: '#fb923c' },
+        { label: 'Kraken Bid (ZAR)', scale: 'price', stroke: '#22c55e' },
+        { label: 'Kraken Ask (ZAR)', scale: 'price', stroke: '#16a34a' },
+        { label: 'Nominal K→L %', scale: 'percent', stroke: '#fbbf24' },
+        { label: 'Nominal L→K %', scale: 'percent', stroke: '#fde68a' },
+        { label: 'Effective K→L %', scale: 'percent', stroke: '#f43f5e' },
+        { label: 'Effective L→K %', scale: 'percent', stroke: '#fda4af' }
+      ]
+    };
+    plotRef.current = new uPlot(options, data.series, containerRef.current);
+    const handleResize = () => {
+      if (containerRef.current && plotRef.current) {
+        plotRef.current.setSize({ width: containerRef.current.clientWidth, height: 320 });
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      plotRef.current?.destroy();
+      plotRef.current = null;
+      window.removeEventListener('resize', handleResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asset]);
+
+  useEffect(() => {
+    if (plotRef.current) {
+      plotRef.current.setData(data.series);
+    }
+  }, [data]);
+
+  return (
+    <section className="card p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">{asset} chart</h3>
+        <div className="flex items-center gap-2 text-xs">
+          <label htmlFor={`${asset}-agg`}>Aggregation</label>
+          <select
+            id={`${asset}-agg`}
+            value={agg.minutes}
+            onChange={(event) => {
+              const minutes = Number(event.target.value);
+              const next = AGG_OPTIONS.find((opt) => opt.minutes === minutes) ?? AGG_OPTIONS[0];
+              setAgg(next);
+            }}
+            className="bg-slate-800 border border-slate-700 rounded px-2 py-1"
+          >
+            {AGG_OPTIONS.map((option) => (
+              <option key={option.minutes} value={option.minutes}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => {
+              const latest = data.aggregated[data.aggregated.length - 1];
+              if (latest) {
+                onExplain({ asset, sample: latest });
+              }
+            }}
+            className="bg-slate-700 hover:bg-slate-600"
+          >
+            Explain spike
+          </button>
+        </div>
+      </div>
+      <div ref={containerRef} className="w-full overflow-hidden" />
+    </section>
+  );
+}
+
+export default AssetChart;

--- a/svc-arbi-dash/app/src/components/Calculators.tsx
+++ b/svc-arbi-dash/app/src/components/Calculators.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState } from 'react';
+import { percentageDifference } from '../lib/calc';
+import { convertGBPToZAR, convertZARToGBP, convertUSDToZAR, convertZARToUSD } from '../lib/fx';
+import { FxQuote } from '../hooks/useFrankfurter';
+
+interface CalculatorsProps {
+  quotes: Record<'GBPZAR' | 'USDZAR', FxQuote | null>;
+}
+
+export function Calculators({ quotes }: CalculatorsProps) {
+  const [v1, setV1] = useState(0);
+  const [v2, setV2] = useState(0);
+  const [zarValue, setZarValue] = useState(0);
+  const [gbpValue, setGbpValue] = useState(0);
+  const [usdValue, setUsdValue] = useState(0);
+
+  const diff = useMemo(() => percentageDifference(v1, v2), [v1, v2]);
+
+  const gbpZarRate = quotes.GBPZAR?.rate ?? null;
+  const usdZarRate = quotes.USDZAR?.rate ?? null;
+
+  const converted = useMemo(() => {
+    if (!gbpZarRate || !usdZarRate) {
+      return null;
+    }
+    return {
+      zarToGbp: convertZARToGBP(zarValue, gbpZarRate),
+      gbpToZar: convertGBPToZAR(gbpValue, gbpZarRate),
+      zarToUsd: convertZARToUSD(zarValue, usdZarRate),
+      usdToZar: convertUSDToZAR(usdValue, usdZarRate)
+    };
+  }, [zarValue, gbpValue, usdValue, gbpZarRate, usdZarRate]);
+
+  return (
+    <section className="card p-4 space-y-4">
+      <h3 className="text-lg font-semibold">Calculators</h3>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <h4 className="font-semibold">Percentage difference</h4>
+          <div className="flex items-center gap-2 text-sm">
+            <label htmlFor="diff-v1" className="w-24">
+              Value 1
+            </label>
+            <input id="diff-v1" type="number" value={v1} onChange={(event) => setV1(Number(event.target.value))} />
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <label htmlFor="diff-v2" className="w-24">
+              Value 2
+            </label>
+            <input id="diff-v2" type="number" value={v2} onChange={(event) => setV2(Number(event.target.value))} />
+          </div>
+          <p className="text-xs text-slate-300">Absolute difference: {diff.absolute.toFixed(4)}</p>
+          <p className="text-xs text-slate-300">
+            Relative %: {diff.relativePct === null ? 'undefined (v1 = 0)' : `${diff.relativePct.toFixed(4)}%`}
+          </p>
+          <p className="text-xs text-slate-300">
+            Percentage points: {diff.percentagePoints === null ? 'n/a' : diff.percentagePoints.toFixed(4)}
+          </p>
+        </div>
+        <div className="space-y-2">
+          <h4 className="font-semibold">FX converters</h4>
+          <p className="text-xs text-slate-400">
+            GBP↔ZAR quote: {gbpZarRate ? gbpZarRate.toFixed(4) : 'loading…'} · USD↔ZAR quote: {usdZarRate ? usdZarRate.toFixed(4) : 'loading…'}
+          </p>
+          <p className="text-xs text-slate-500">
+            Last update: {quotes.GBPZAR ? new Date(quotes.GBPZAR.fetchedAt).toLocaleString('en-GB', { hour12: false }) : '—'}
+          </p>
+          <div className="flex items-center gap-2 text-sm">
+            <label htmlFor="zar-value" className="w-24">
+              ZAR
+            </label>
+            <input id="zar-value" type="number" value={zarValue} onChange={(event) => setZarValue(Number(event.target.value))} />
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <label htmlFor="gbp-value" className="w-24">
+              GBP
+            </label>
+            <input id="gbp-value" type="number" value={gbpValue} onChange={(event) => setGbpValue(Number(event.target.value))} />
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <label htmlFor="usd-value" className="w-24">
+              USD
+            </label>
+            <input id="usd-value" type="number" value={usdValue} onChange={(event) => setUsdValue(Number(event.target.value))} />
+          </div>
+          {converted ? (
+            <div className="text-xs text-slate-300 space-y-1">
+              <div>ZAR → GBP: £{converted.zarToGbp.toFixed(2)}</div>
+              <div>GBP → ZAR: R{converted.gbpToZar.toFixed(2)}</div>
+              <div>ZAR → USD: ${converted.zarToUsd.toFixed(2)}</div>
+              <div>USD → ZAR: R{converted.usdToZar.toFixed(2)}</div>
+            </div>
+          ) : (
+            <p className="text-xs text-amber-400">Waiting for FX quotes…</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default Calculators;

--- a/svc-arbi-dash/app/src/components/CombinedChart.tsx
+++ b/svc-arbi-dash/app/src/components/CombinedChart.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import uPlot from 'uplot';
+import { Sample, AssetSymbol } from '../lib/types';
+import { LocalSettings } from '../hooks/useLocalSettings';
+import { effectiveArbPercentage, withdrawalAmortizationPct } from '../lib/calc';
+
+const ASSETS: AssetSymbol[] = ['ETH', 'BTC', 'USDT'];
+
+type CombinedChartProps = {
+  samples: Sample[];
+  settings: LocalSettings;
+  onExplain: (payload: { asset: AssetSymbol; sample: Sample }) => void;
+};
+
+function computeTopDirection(sample: Sample, asset: AssetSymbol, settings: LocalSettings) {
+  const snapshot = sample[asset];
+  const slippage = settings.slippageCaps[asset];
+  const fees = {
+    kraken: settings.fees.kraken[asset].taker,
+    luno: settings.fees.luno[asset].taker
+  };
+  const withdrawalK = settings.withdrawalAmortization && snapshot.krakenAskGBP
+    ? withdrawalAmortizationPct(settings.withdrawalFees[asset].kraken, snapshot.krakenAskGBP, settings.balances.krakenGBP)
+    : 0;
+  const withdrawalL = settings.withdrawalAmortization && snapshot.krakenBidGBP
+    ? withdrawalAmortizationPct(
+        settings.withdrawalFees[asset].luno,
+        snapshot.krakenBidGBP,
+        settings.balances.lunoZAR / sample.fx_gbp_zar
+      )
+    : 0;
+  const directions = [
+    {
+      direction: 'K→L',
+      nominal: snapshot.arb_buyKraken_sellLuno_pct,
+      effective:
+        snapshot.arb_buyKraken_sellLuno_pct === null
+          ? null
+          : effectiveArbPercentage({
+              nominalPct: snapshot.arb_buyKraken_sellLuno_pct,
+              legs: [
+                { feePct: fees.kraken, slippagePct: slippage },
+                { feePct: fees.luno, slippagePct: slippage }
+              ],
+              withdrawalPct: withdrawalK
+            })
+    },
+    {
+      direction: 'L→K',
+      nominal: snapshot.arb_buyLuno_sellKraken_pct,
+      effective:
+        snapshot.arb_buyLuno_sellKraken_pct === null
+          ? null
+          : effectiveArbPercentage({
+              nominalPct: snapshot.arb_buyLuno_sellKraken_pct,
+              legs: [
+                { feePct: fees.luno, slippagePct: slippage },
+                { feePct: fees.kraken, slippagePct: slippage }
+              ],
+              withdrawalPct: withdrawalL
+            })
+    }
+  ];
+  const best = directions.sort((a, b) => (b.effective ?? -Infinity) - (a.effective ?? -Infinity))[0];
+  return best ?? null;
+}
+
+export function CombinedChart({ samples, settings, onExplain }: CombinedChartProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const plotRef = useRef<uPlot | null>(null);
+  const [overlayAsset, setOverlayAsset] = useState<AssetSymbol>('ETH');
+
+  const data = useMemo(() => {
+    const times = samples.map((s) => s.ts / 1000);
+    const fx = samples.map((s) => s.fx_gbp_zar);
+    const effectiveSeries = ASSETS.map((asset) =>
+      samples.map((sample) => {
+        const best = computeTopDirection(sample, asset, settings);
+        return best?.effective ?? null;
+      })
+    );
+    const overlaySeries = samples.map((sample) => ({
+      lunoBid: sample[overlayAsset].lunoBestBidZAR,
+      krakenAsk: sample[overlayAsset].krakenAskZAR
+    }));
+    return { times, fx, effectiveSeries, overlaySeries };
+  }, [samples, settings, overlayAsset]);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+    const series: uPlot.Series[] = [
+      {},
+      { label: 'ETH', scale: 'percent', stroke: '#f97316' },
+      { label: 'BTC', scale: 'percent', stroke: '#38bdf8' },
+      { label: 'USDT', scale: 'percent', stroke: '#a855f7' },
+      { label: 'FX GBP→ZAR', scale: 'fx', stroke: '#facc15' },
+      { label: 'Luno Bid (ZAR)', scale: 'price', stroke: '#22d3ee', show: false },
+      { label: 'Kraken Ask (ZAR)', scale: 'price', stroke: '#f87171', show: false }
+    ];
+    const options: uPlot.Options = {
+      width: containerRef.current.clientWidth,
+      height: 340,
+      tzDate: (ts) => uPlot.tzDate(new Date(ts * 1000), 'Europe/London'),
+      scales: {
+        x: { time: true },
+        percent: { auto: true },
+        fx: { auto: true },
+        price: { auto: true }
+      },
+      series
+    };
+    plotRef.current = new uPlot(options, [data.times, ...data.effectiveSeries, data.fx, data.overlaySeries.map((o) => o.lunoBid ?? null), data.overlaySeries.map((o) => o.krakenAsk ?? null)], containerRef.current);
+    const handleResize = () => {
+      if (containerRef.current && plotRef.current) {
+        plotRef.current.setSize({ width: containerRef.current.clientWidth, height: 340 });
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      plotRef.current?.destroy();
+      plotRef.current = null;
+      window.removeEventListener('resize', handleResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!plotRef.current) {
+      return;
+    }
+    const overlayLuno = data.overlaySeries.map((o) => o.lunoBid ?? null);
+    const overlayKraken = data.overlaySeries.map((o) => o.krakenAsk ?? null);
+    plotRef.current.setData([data.times, ...data.effectiveSeries, data.fx, overlayLuno, overlayKraken]);
+  }, [data]);
+
+  return (
+    <section className="card p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Combined effective arbitrage</h3>
+        <div className="flex items-center gap-2 text-xs">
+          <label htmlFor="overlay-select">Overlay asset legs</label>
+          <select
+            id="overlay-select"
+            value={overlayAsset}
+            onChange={(event) => setOverlayAsset(event.target.value as AssetSymbol)}
+            className="bg-slate-800 border border-slate-700 rounded px-2 py-1"
+          >
+            {ASSETS.map((asset) => (
+              <option key={asset} value={asset}>
+                {asset}
+              </option>
+            ))}
+          </select>
+          <button
+            className="bg-slate-700 hover:bg-slate-600"
+            onClick={() => {
+              const latest = samples[samples.length - 1];
+              if (latest) {
+                onExplain({ asset: overlayAsset, sample: latest });
+              }
+            }}
+          >
+            Explain spike
+          </button>
+        </div>
+      </div>
+      <div ref={containerRef} className="w-full overflow-hidden" />
+    </section>
+  );
+}
+
+export default CombinedChart;

--- a/svc-arbi-dash/app/src/components/ExplainSpikeModal.tsx
+++ b/svc-arbi-dash/app/src/components/ExplainSpikeModal.tsx
@@ -1,0 +1,73 @@
+import { effectiveArbPercentage, slippageDeduction, withdrawalAmortizationPct } from '../lib/calc';
+import { Sample, AssetSymbol } from '../lib/types';
+import { LocalSettings } from '../hooks/useLocalSettings';
+
+interface ExplainSpikeModalProps {
+  open: boolean;
+  asset: AssetSymbol | null;
+  sample: Sample | null;
+  settings: LocalSettings;
+  onClose: () => void;
+}
+
+export function ExplainSpikeModal({ open, asset, sample, settings, onClose }: ExplainSpikeModalProps) {
+  if (!open || !asset || !sample) {
+    return null;
+  }
+  const snapshot = sample[asset];
+  const nominalK = snapshot.arb_buyKraken_sellLuno_pct ?? 0;
+  const nominalL = snapshot.arb_buyLuno_sellKraken_pct ?? 0;
+  const legs = [
+    { feePct: settings.fees.kraken[asset].taker, slippagePct: settings.slippageCaps[asset] },
+    { feePct: settings.fees.luno[asset].taker, slippagePct: settings.slippageCaps[asset] }
+  ];
+  const withdrawalK = snapshot.krakenAskGBP
+    ? withdrawalAmortizationPct(settings.withdrawalFees[asset].kraken, snapshot.krakenAskGBP, settings.balances.krakenGBP)
+    : 0;
+  const withdrawalL = snapshot.krakenBidGBP
+    ? withdrawalAmortizationPct(
+        settings.withdrawalFees[asset].luno,
+        snapshot.krakenBidGBP,
+        settings.balances.lunoZAR / sample.fx_gbp_zar
+      )
+    : 0;
+  const effectiveK = effectiveArbPercentage({ nominalPct: nominalK, legs, withdrawalPct: withdrawalK });
+  const reverseLegs = [...legs].reverse();
+  const effectiveL = effectiveArbPercentage({ nominalPct: nominalL, legs: reverseLegs, withdrawalPct: withdrawalL });
+  const legFeeCost = legs.reduce((acc, leg) => acc + (leg.feePct ?? 0), 0);
+  const slippage = slippageDeduction(legs);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="card max-w-xl w-full p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Explain spike — {asset}</h3>
+          <button onClick={onClose} className="bg-slate-700 hover:bg-slate-600 text-xs">
+            Close
+          </button>
+        </div>
+        <p className="text-xs text-slate-300">Timestamp: {new Date(sample.ts).toLocaleString('en-GB', { hour12: false })}</p>
+        <div className="grid gap-3 md:grid-cols-2 text-sm">
+          <div className="space-y-1">
+            <h4 className="font-semibold">Kraken → Luno</h4>
+            <div>Nominal: {nominalK.toFixed(3)}%</div>
+            <div>Effective: {effectiveK.toFixed(3)}%</div>
+            <div>Fees: {legFeeCost.toFixed(3)}%</div>
+            <div>Slippage cap: {slippage.toFixed(3)}%</div>
+            <div>Withdrawal amortization: {withdrawalK.toFixed(3)}%</div>
+          </div>
+          <div className="space-y-1">
+            <h4 className="font-semibold">Luno → Kraken</h4>
+            <div>Nominal: {nominalL.toFixed(3)}%</div>
+            <div>Effective: {effectiveL.toFixed(3)}%</div>
+            <div>Fees: {legFeeCost.toFixed(3)}%</div>
+            <div>Slippage cap: {slippage.toFixed(3)}%</div>
+            <div>Withdrawal amortization: {withdrawalL.toFixed(3)}%</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ExplainSpikeModal;

--- a/svc-arbi-dash/app/src/components/ExportCsvButton.tsx
+++ b/svc-arbi-dash/app/src/components/ExportCsvButton.tsx
@@ -1,0 +1,26 @@
+import { downloadCsv, toCsv } from '../lib/csv';
+
+type ExportCsvButtonProps<T extends Record<string, unknown>> = {
+  filename: string;
+  rows: T[];
+};
+
+function ExportCsvButton<T extends Record<string, unknown>>({ filename, rows }: ExportCsvButtonProps<T>) {
+  return (
+    <button
+      onClick={() => {
+        if (!rows.length) {
+          return;
+        }
+        const headers = Object.keys(rows[0]);
+        const csv = toCsv(headers, rows);
+        downloadCsv(filename, csv);
+      }}
+      className="bg-slate-700 hover:bg-slate-600"
+    >
+      Export CSV
+    </button>
+  );
+}
+
+export default ExportCsvButton;

--- a/svc-arbi-dash/app/src/components/HeaderTiles.tsx
+++ b/svc-arbi-dash/app/src/components/HeaderTiles.tsx
@@ -1,0 +1,115 @@
+import { DateTime } from 'luxon';
+import { effectiveArbPercentage, withdrawalAmortizationPct } from '../lib/calc';
+import { formatDateTime } from '../lib/time';
+import { AssetSymbol, Sample } from '../lib/types';
+import { LocalSettings } from '../hooks/useLocalSettings';
+import { FxQuote } from '../hooks/useFrankfurter';
+
+const ASSETS: AssetSymbol[] = ['ETH', 'BTC', 'USDT'];
+
+function computeDirection(
+  asset: AssetSymbol,
+  sample: Sample,
+  settings: LocalSettings,
+  direction: 'KRAKEN_TO_LUNO' | 'LUNO_TO_KRAKEN'
+) {
+  const snapshot = sample[asset];
+  const feeKraken = settings.fees.kraken[asset].taker;
+  const feeLuno = settings.fees.luno[asset].taker;
+  const slippage = settings.slippageCaps[asset];
+  const legs = [
+    { feePct: direction === 'KRAKEN_TO_LUNO' ? feeKraken : feeLuno, slippagePct: slippage },
+    { feePct: direction === 'KRAKEN_TO_LUNO' ? feeLuno : feeKraken, slippagePct: slippage }
+  ];
+  const nominal =
+    direction === 'KRAKEN_TO_LUNO'
+      ? snapshot.arb_buyKraken_sellLuno_pct ?? null
+      : snapshot.arb_buyLuno_sellKraken_pct ?? null;
+  if (nominal === null) {
+    return null;
+  }
+  let withdrawal = 0;
+  if (settings.withdrawalAmortization) {
+    const notionalGBP =
+      direction === 'KRAKEN_TO_LUNO'
+        ? settings.balances.krakenGBP
+        : settings.balances.lunoZAR / sample.fx_gbp_zar;
+    const perUnit =
+      direction === 'KRAKEN_TO_LUNO' ? snapshot.krakenAskGBP ?? 0 : snapshot.krakenBidGBP ?? 0;
+    const withdrawalFee =
+      settings.withdrawalFees[asset][direction === 'KRAKEN_TO_LUNO' ? 'kraken' : 'luno'];
+    if (perUnit && notionalGBP) {
+      withdrawal = withdrawalAmortizationPct(withdrawalFee, perUnit, notionalGBP);
+    }
+  }
+  const effective = effectiveArbPercentage({ nominalPct: nominal, legs, withdrawalPct: withdrawal });
+  return { nominal, effective, withdrawal, direction };
+}
+
+function describeAge(sampleTs: number | null): string {
+  if (!sampleTs) {
+    return 'No data';
+  }
+  const diff = DateTime.now().diff(DateTime.fromMillis(sampleTs), 'minutes').minutes;
+  if (diff < 1) {
+    return 'Updated < 1 min ago';
+  }
+  return `Updated ${Math.round(diff)} min ago`;
+}
+
+type HeaderTilesProps = {
+  sample: Sample | null;
+  settings: LocalSettings;
+  quotes: Record<'GBPZAR' | 'USDZAR', FxQuote | null>;
+  onSettingsOpen: () => void;
+};
+
+export function HeaderTiles({ sample, settings, quotes, onSettingsOpen }: HeaderTilesProps) {
+  const ageLabel = describeAge(sample?.ts ?? null);
+  return (
+    <section className="grid gap-4 md:grid-cols-4">
+      <div className="card p-4 space-y-2">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">FX GBP→ZAR</h2>
+          <button onClick={onSettingsOpen} className="bg-slate-700 hover:bg-slate-600 text-xs px-2 py-1">
+            Settings
+          </button>
+        </div>
+        <p className="text-3xl font-mono">
+          {sample ? sample.fx_gbp_zar.toFixed(3) : '—'}
+        </p>
+        <p className="text-sm text-slate-400">
+          Frankfurter: {quotes.GBPZAR ? quotes.GBPZAR.rate.toFixed(3) : '…'}{' '}
+          {quotes.GBPZAR ? `(as of ${formatDateTime(quotes.GBPZAR.fetchedAt)})` : ''}
+        </p>
+        <p className="text-xs text-slate-500">{ageLabel}</p>
+        <p className="text-xs text-slate-500">
+          Balances — Luno: R{settings.balances.lunoZAR.toLocaleString()} · Kraken: £{settings.balances.krakenGBP.toLocaleString()}
+        </p>
+      </div>
+      {ASSETS.map((asset) => {
+        const kToL = sample ? computeDirection(asset, sample, settings, 'KRAKEN_TO_LUNO') : null;
+        const lToK = sample ? computeDirection(asset, sample, settings, 'LUNO_TO_KRAKEN') : null;
+        const best = [kToL, lToK].filter(Boolean).sort((a, b) => (b?.effective ?? -Infinity) - (a?.effective ?? -Infinity))[0] ?? null;
+        return (
+          <div key={asset} className="card p-4 space-y-2">
+            <h3 className="text-lg font-semibold">{asset}</h3>
+            <div className="flex justify-between text-sm text-slate-400">
+              <span>K→L</span>
+              <span>{kToL ? `${kToL.effective.toFixed(2)}%` : '—'}</span>
+            </div>
+            <div className="flex justify-between text-sm text-slate-400">
+              <span>L→K</span>
+              <span>{lToK ? `${lToK.effective.toFixed(2)}%` : '—'}</span>
+            </div>
+            <p className="text-xs text-slate-500">
+              Nominal best: {best ? `${best.nominal.toFixed(2)}% (${best.direction === 'KRAKEN_TO_LUNO' ? 'K→L' : 'L→K'})` : '—'}
+            </p>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+export default HeaderTiles;

--- a/svc-arbi-dash/app/src/components/HealthStrip.tsx
+++ b/svc-arbi-dash/app/src/components/HealthStrip.tsx
@@ -1,0 +1,87 @@
+import { useMemo, useState } from 'react';
+import { minutesBetween } from '../lib/time';
+import { Sample } from '../lib/types';
+
+type HealthStripProps = {
+  samples: Sample[];
+  frankfurterError: string | null;
+  dataError: string | null;
+  tradeError: string | null;
+};
+
+function hasNullLegs(samples: Sample[]): boolean {
+  return samples.slice(-3).some((sample) => {
+    return ['ETH', 'BTC', 'USDT'].some((asset) => {
+      const snapshot = sample[asset as 'ETH'];
+      return (
+        snapshot.lunoBestBidZAR === null ||
+        snapshot.lunoBestAskZAR === null ||
+        snapshot.krakenBidGBP === null ||
+        snapshot.krakenAskGBP === null
+      );
+    });
+  });
+}
+
+function Badge({ label, tone }: { label: string; tone: 'ok' | 'warn' | 'error' }) {
+  const base = 'px-2 py-1 rounded text-xs font-semibold uppercase tracking-wide';
+  if (tone === 'ok') {
+    return <span className={`${base} bg-emerald-900 text-emerald-300`}>{label}</span>;
+  }
+  if (tone === 'warn') {
+    return <span className={`${base} bg-amber-900 text-amber-300`}>{label}</span>;
+  }
+  return <span className={`${base} bg-rose-900 text-rose-200`}>{label}</span>;
+}
+
+export function HealthStrip({ samples, frankfurterError, dataError, tradeError }: HealthStripProps) {
+  const [open, setOpen] = useState(false);
+
+  const flags = useMemo(() => {
+    const now = Date.now();
+    const latestTs = samples.length ? samples[samples.length - 1].ts : null;
+    const stale = latestTs ? minutesBetween(latestTs, now) > 2 : true;
+    const nullLeg = hasNullLegs(samples);
+    const items = [] as Array<{ label: string; tone: 'ok' | 'warn' | 'error'; detail?: string }>;
+    items.push({ label: stale ? 'Stale data' : 'Fresh data', tone: stale ? 'warn' : 'ok' });
+    items.push({ label: nullLeg ? 'Null legs detected' : 'Legs healthy', tone: nullLeg ? 'warn' : 'ok' });
+    if (frankfurterError) {
+      items.push({ label: 'FX issue', tone: 'error', detail: frankfurterError });
+    }
+    if (dataError) {
+      items.push({ label: 'Data API error', tone: 'error', detail: dataError });
+    }
+    if (tradeError) {
+      items.push({ label: 'Trades API error', tone: 'error', detail: tradeError });
+    }
+    if (items.length === 2 && !stale && !nullLeg) {
+      items.push({ label: 'Systems nominal', tone: 'ok' });
+    }
+    return items;
+  }, [samples, frankfurterError, dataError, tradeError]);
+
+  return (
+    <section className="card p-3 flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {flags.map((flag) => (
+          <Badge key={flag.label} label={flag.label} tone={flag.tone} />
+        ))}
+        <button onClick={() => setOpen((prev) => !prev)} className="ml-auto bg-slate-700 hover:bg-slate-600 text-xs">
+          Diagnostics
+        </button>
+      </div>
+      {open ? (
+        <div className="text-xs text-slate-300 space-y-1">
+          {flags
+            .filter((flag) => flag.detail)
+            .map((flag) => (
+              <div key={flag.label}>{flag.label}: {flag.detail}</div>
+            ))}
+          {!flags.some((flag) => flag.detail) && <p>No recent errors.</p>}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export default HealthStrip;

--- a/svc-arbi-dash/app/src/components/PositionSizer.tsx
+++ b/svc-arbi-dash/app/src/components/PositionSizer.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from 'react';
+import { computePositionSize, effectiveArbPercentage, PositionSizerInput } from '../lib/calc';
+import { Sample, AssetSymbol } from '../lib/types';
+import { LocalSettings } from '../hooks/useLocalSettings';
+
+const ASSETS: AssetSymbol[] = ['ETH', 'BTC', 'USDT'];
+
+type PositionSizerProps = {
+  sample: Sample | null;
+  settings: LocalSettings;
+};
+
+export function PositionSizer({ sample, settings }: PositionSizerProps) {
+  const [lunoCap, setLunoCap] = useState(settings.balances.lunoZAR);
+  const [krakenCap, setKrakenCap] = useState(settings.balances.krakenGBP);
+
+  const rows = useMemo(() => {
+    if (!sample) {
+      return [];
+    }
+   return ASSETS.map((asset) => {
+      const snapshot = sample[asset];
+      const slippage = settings.slippageCaps[asset];
+      const fees = {
+        kraken: settings.fees.kraken[asset].taker,
+        luno: settings.fees.luno[asset].taker
+      };
+      const nominalK = snapshot.arb_buyKraken_sellLuno_pct ?? 0;
+      const nominalL = snapshot.arb_buyLuno_sellKraken_pct ?? 0;
+      const effectiveK = effectiveArbPercentage({
+        nominalPct: nominalK,
+        legs: [
+          { feePct: fees.kraken, slippagePct: slippage },
+          { feePct: fees.luno, slippagePct: slippage }
+        ]
+      });
+      const effectiveL = effectiveArbPercentage({
+        nominalPct: nominalL,
+        legs: [
+          { feePct: fees.luno, slippagePct: slippage },
+          { feePct: fees.kraken, slippagePct: slippage }
+        ]
+      });
+      const inputBase: Omit<PositionSizerInput, 'direction'> = {
+        asset,
+        balances: settings.balances,
+        caps: { lunoZAR: lunoCap, krakenGBP: krakenCap },
+        prices: {
+          krakenAskGBP: snapshot.krakenAskGBP,
+          krakenBidGBP: snapshot.krakenBidGBP,
+          lunoAskZAR: snapshot.lunoBestAskZAR,
+          lunoBidZAR: snapshot.lunoBestBidZAR,
+          fxGBPZAR: sample.fx_gbp_zar
+        },
+        effectivePct: 0
+      };
+      const kToL = computePositionSize({ ...inputBase, direction: 'KRAKEN_TO_LUNO', effectivePct: effectiveK });
+      const lToK = computePositionSize({ ...inputBase, direction: 'LUNO_TO_KRAKEN', effectivePct: effectiveL });
+      return { asset, kToL, lToK };
+    });
+  }, [sample, settings.balances, lunoCap, krakenCap]);
+
+  return (
+    <section className="card p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Position sizer</h3>
+        <div className="flex gap-2 text-xs">
+          <label className="flex items-center gap-2">
+            Luno cap (ZAR)
+            <input type="number" value={lunoCap} onChange={(event) => setLunoCap(Number(event.target.value))} />
+          </label>
+          <label className="flex items-center gap-2">
+            Kraken cap (GBP)
+            <input type="number" value={krakenCap} onChange={(event) => setKrakenCap(Number(event.target.value))} />
+          </label>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead className="bg-slate-900 text-slate-300">
+            <tr>
+              <th className="px-3 py-2 text-left">Asset</th>
+              <th className="px-3 py-2 text-right">K→L Notional (GBP)</th>
+              <th className="px-3 py-2 text-right">K→L P&amp;L (GBP)</th>
+              <th className="px-3 py-2 text-right">L→K Notional (GBP)</th>
+              <th className="px-3 py-2 text-right">L→K P&amp;L (GBP)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.asset} className="odd:bg-slate-900/40">
+                <td className="px-3 py-2">{row.asset}</td>
+                <td className="px-3 py-2 text-right font-mono">
+                  {row.kToL ? row.kToL.maxNotionalGBP.toFixed(2) : '—'}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-emerald-400">
+                  {row.kToL ? row.kToL.estimatedPnlGBP.toFixed(2) : '—'}
+                </td>
+                <td className="px-3 py-2 text-right font-mono">
+                  {row.lToK ? row.lToK.maxNotionalGBP.toFixed(2) : '—'}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-emerald-400">
+                  {row.lToK ? row.lToK.estimatedPnlGBP.toFixed(2) : '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default PositionSizer;

--- a/svc-arbi-dash/app/src/components/RecentTable.tsx
+++ b/svc-arbi-dash/app/src/components/RecentTable.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useState } from 'react';
+import { Sample, AssetSymbol } from '../lib/types';
+import { formatDateTime } from '../lib/time';
+import { LocalSettings } from '../hooks/useLocalSettings';
+import { effectiveArbPercentage, withdrawalAmortizationPct } from '../lib/calc';
+import ExportCsvButton from './ExportCsvButton';
+
+const MAX_ROWS = 50;
+const ASSETS: AssetSymbol[] = ['ETH', 'BTC', 'USDT'];
+
+type RecentTableProps = {
+  samples: Sample[];
+  settings: LocalSettings;
+};
+
+export function RecentTable({ samples, settings }: RecentTableProps) {
+  const [assetFilter, setAssetFilter] = useState<'ALL' | AssetSymbol>('ALL');
+  const [profitableOnly, setProfitableOnly] = useState(false);
+  const [threshold, setThreshold] = useState(0);
+  const [rowsToShow, setRowsToShow] = useState(MAX_ROWS);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const rows = useMemo(() => {
+    const slice = sortDir === 'desc' ? [...samples].reverse() : [...samples];
+    const selected = slice.slice(-rowsToShow);
+    return selected
+      .map((sample) => {
+        const perAssetEntries = ASSETS.map((asset) => {
+          const snapshot = sample[asset];
+          const slippage = settings.slippageCaps[asset];
+          const fees = {
+            kraken: settings.fees.kraken[asset].taker,
+            luno: settings.fees.luno[asset].taker
+          };
+          const withdrawalK = settings.withdrawalAmortization && snapshot.krakenAskGBP
+            ? withdrawalAmortizationPct(
+                settings.withdrawalFees[asset].kraken,
+                snapshot.krakenAskGBP,
+                settings.balances.krakenGBP
+              )
+            : 0;
+          const withdrawalL = settings.withdrawalAmortization && snapshot.krakenBidGBP
+            ? withdrawalAmortizationPct(
+                settings.withdrawalFees[asset].luno,
+                snapshot.krakenBidGBP,
+                settings.balances.lunoZAR / sample.fx_gbp_zar
+              )
+            : 0;
+          const nominalK = snapshot.arb_buyKraken_sellLuno_pct;
+          const nominalL = snapshot.arb_buyLuno_sellKraken_pct;
+          const effectiveK =
+            nominalK === null
+              ? null
+              : effectiveArbPercentage({
+                  nominalPct: nominalK,
+                  legs: [
+                    { feePct: fees.kraken, slippagePct: slippage },
+                    { feePct: fees.luno, slippagePct: slippage }
+                  ],
+                  withdrawalPct: withdrawalK
+                });
+          const effectiveL =
+            nominalL === null
+              ? null
+              : effectiveArbPercentage({
+                  nominalPct: nominalL,
+                  legs: [
+                    { feePct: fees.luno, slippagePct: slippage },
+                    { feePct: fees.kraken, slippagePct: slippage }
+                  ],
+                  withdrawalPct: withdrawalL
+                });
+          return [
+            asset,
+            {
+              snapshot,
+              nominalK,
+              nominalL,
+              effectiveK,
+              effectiveL
+            }
+          ];
+        });
+        const perAsset = Object.fromEntries(perAssetEntries) as Record<
+          AssetSymbol,
+          {
+            snapshot: Sample['ETH'];
+            nominalK: number | null;
+            nominalL: number | null;
+            effectiveK: number | null;
+            effectiveL: number | null;
+          }
+        >;
+        return {
+          ts: sample.ts,
+          fx: sample.fx_gbp_zar,
+          perAsset
+        };
+      })
+      .filter((row) => {
+        if (assetFilter === 'ALL') {
+          return true;
+        }
+        const data = row.perAsset[assetFilter];
+        if (!profitableOnly) {
+          return true;
+        }
+        const effective = Math.max(data.effectiveK ?? -Infinity, data.effectiveL ?? -Infinity);
+        return effective >= threshold;
+      });
+  }, [samples, settings, assetFilter, profitableOnly, threshold, rowsToShow, sortDir]);
+
+  const csvRows = useMemo(() => {
+    return rows.map((row) => ({
+      ts_epoch: row.ts,
+      ts_local: formatDateTime(row.ts),
+      fx_gbp_zar: row.fx,
+      ETH_nominal_KL: row.perAsset.ETH.nominalK ?? '',
+      ETH_nominal_LK: row.perAsset.ETH.nominalL ?? '',
+      ETH_effective_KL: row.perAsset.ETH.effectiveK ?? '',
+      ETH_effective_LK: row.perAsset.ETH.effectiveL ?? '',
+      BTC_nominal_KL: row.perAsset.BTC.nominalK ?? '',
+      BTC_nominal_LK: row.perAsset.BTC.nominalL ?? '',
+      BTC_effective_KL: row.perAsset.BTC.effectiveK ?? '',
+      BTC_effective_LK: row.perAsset.BTC.effectiveL ?? '',
+      USDT_nominal_KL: row.perAsset.USDT.nominalK ?? '',
+      USDT_nominal_LK: row.perAsset.USDT.nominalL ?? '',
+      USDT_effective_KL: row.perAsset.USDT.effectiveK ?? '',
+      USDT_effective_LK: row.perAsset.USDT.effectiveL ?? ''
+    }));
+  }, [rows]);
+
+  return (
+    <section className="card p-4 space-y-4">
+      <div className="flex flex-wrap items-center gap-3 text-xs">
+        <div className="flex items-center gap-2">
+          <label htmlFor="asset-filter">Asset</label>
+          <select
+            id="asset-filter"
+            className="bg-slate-800 border border-slate-700 rounded px-2 py-1"
+            value={assetFilter}
+            onChange={(event) => setAssetFilter(event.target.value as 'ALL' | AssetSymbol)}
+          >
+            <option value="ALL">All</option>
+            {ASSETS.map((asset) => (
+              <option key={asset} value={asset}>
+                {asset}
+              </option>
+            ))}
+          </select>
+        </div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={profitableOnly}
+            onChange={(event) => setProfitableOnly(event.target.checked)}
+          />
+          Profitable only (≥ threshold)
+        </label>
+        <input
+          type="number"
+          value={threshold}
+          onChange={(event) => setThreshold(Number(event.target.value))}
+          className="w-20"
+        />
+        <label className="flex items-center gap-2">
+          Rows
+          <input
+            type="number"
+            min={10}
+            max={500}
+            value={rowsToShow}
+            onChange={(event) => setRowsToShow(Number(event.target.value))}
+            className="w-20"
+          />
+        </label>
+        <button
+          onClick={() => setSortDir((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
+          className="bg-slate-700 hover:bg-slate-600"
+        >
+          Sort {sortDir === 'asc' ? '▲' : '▼'}
+        </button>
+        <ExportCsvButton filename="recent-samples.csv" rows={csvRows} />
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead className="bg-slate-900 text-slate-300">
+            <tr>
+              <th className="px-3 py-2 text-left">Time (UK)</th>
+              <th className="px-3 py-2 text-right">FX GBP→ZAR</th>
+              {ASSETS.map((asset) => (
+                <th key={asset} className="px-3 py-2 text-left">
+                  {asset}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.ts} className="odd:bg-slate-900/40">
+                <td className="px-3 py-2 whitespace-nowrap">{formatDateTime(row.ts)}</td>
+                <td className="px-3 py-2 text-right font-mono">{row.fx.toFixed(3)}</td>
+                {ASSETS.map((asset) => {
+                  const data = row.perAsset[asset];
+                  const best = Math.max(data.effectiveK ?? -Infinity, data.effectiveL ?? -Infinity);
+                  const bestDisplay = Number.isFinite(best) ? best.toFixed(2) : '—';
+                  return (
+                    <td key={asset} className="px-3 py-2 align-top whitespace-nowrap">
+                      <div>Nominal K→L: {data.nominalK?.toFixed(2) ?? '—'}%</div>
+                      <div>Nominal L→K: {data.nominalL?.toFixed(2) ?? '—'}%</div>
+                      <div>Effective K→L: {data.effectiveK?.toFixed(2) ?? '—'}%</div>
+                      <div>Effective L→K: {data.effectiveL?.toFixed(2) ?? '—'}%</div>
+                      <div className={best >= threshold ? 'text-emerald-400' : 'text-slate-400'}>Top: {bestDisplay}%</div>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default RecentTable;

--- a/svc-arbi-dash/app/src/components/SettingsDrawer.tsx
+++ b/svc-arbi-dash/app/src/components/SettingsDrawer.tsx
@@ -1,0 +1,117 @@
+import { ChangeEvent } from 'react';
+import { useLocalSettings } from '../hooks/useLocalSettings';
+
+interface SettingsDrawerProps {
+  controller: ReturnType<typeof useLocalSettings>;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function SettingsDrawer({ controller, open, onClose }: SettingsDrawerProps) {
+  const { settings, update, reset, applyProfile, exportProfile, importProfile, profiles } = controller;
+
+  const handleFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      await importProfile(file);
+      event.target.value = '';
+    }
+  };
+
+  return (
+    <aside
+      className={`fixed top-0 right-0 h-full w-full max-w-md transform bg-panel-subtle shadow-lg shadow-black/50 transition-transform duration-200 ${open ? 'translate-x-0' : 'translate-x-full'}`}
+    >
+      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
+        <h3 className="text-lg font-semibold">Settings</h3>
+        <button onClick={onClose} className="bg-slate-700 hover:bg-slate-600 text-xs">
+          Close
+        </button>
+      </div>
+      <div className="p-4 space-y-4 text-sm overflow-y-auto h-full">
+        <section className="space-y-2">
+          <h4 className="font-semibold">History window</h4>
+          <label className="flex items-center gap-2">
+            Hours
+            <input
+              type="number"
+              min={1}
+              max={168}
+              value={settings.historyHours}
+              onChange={(event) => update({ historyHours: Number(event.target.value) })}
+            />
+          </label>
+        </section>
+        <section className="space-y-2">
+          <h4 className="font-semibold">Auto refresh</h4>
+          <label className="flex items-center gap-2">
+            Interval (ms)
+            <input
+              type="number"
+              value={settings.autoRefreshMs}
+              onChange={(event) => update({ autoRefreshMs: Number(event.target.value) })}
+            />
+          </label>
+        </section>
+        <section className="space-y-2">
+          <h4 className="font-semibold">Profiles</h4>
+          <select
+            value={settings.profile}
+            onChange={(event) => applyProfile(event.target.value as keyof typeof profiles)}
+            className="bg-slate-800 border border-slate-700 rounded px-2 py-1"
+          >
+            {(Object.keys(profiles) as Array<keyof typeof profiles>).map((key) => (
+              <option key={key} value={key}>
+                {key}
+              </option>
+            ))}
+          </select>
+          <div className="flex gap-2">
+            <button onClick={exportProfile} className="bg-slate-700 hover:bg-slate-600 text-xs">
+              Export JSON
+            </button>
+            <label className="bg-slate-700 hover:bg-slate-600 text-xs px-3 py-2 rounded cursor-pointer">
+              Import JSON
+              <input type="file" accept="application/json" className="hidden" onChange={handleFile} />
+            </label>
+          </div>
+        </section>
+        <section className="space-y-2">
+          <h4 className="font-semibold">Balances</h4>
+          <label className="flex items-center gap-2">
+            Luno (ZAR)
+            <input
+              type="number"
+              value={settings.balances.lunoZAR}
+              onChange={(event) => update({ balances: { ...settings.balances, lunoZAR: Number(event.target.value) } })}
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            Kraken (GBP)
+            <input
+              type="number"
+              value={settings.balances.krakenGBP}
+              onChange={(event) => update({ balances: { ...settings.balances, krakenGBP: Number(event.target.value) } })}
+            />
+          </label>
+        </section>
+        <section className="space-y-2">
+          <h4 className="font-semibold">Withdrawal amortization</h4>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={settings.withdrawalAmortization}
+              onChange={(event) => update({ withdrawalAmortization: event.target.checked })}
+            />
+            Include withdrawal fees
+          </label>
+        </section>
+        <button onClick={reset} className="bg-rose-700 hover:bg-rose-600 text-xs">
+          Reset defaults
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+export default SettingsDrawer;

--- a/svc-arbi-dash/app/src/components/TaxReports.tsx
+++ b/svc-arbi-dash/app/src/components/TaxReports.tsx
@@ -1,0 +1,197 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { TaxYearSummary } from '../lib/types';
+import ExportCsvButton from './ExportCsvButton';
+
+interface TaxReportsProps {
+  authToken: string;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: {
+      'Cache-Control': 'no-store'
+    }
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed with ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function TaxReports({ authToken }: TaxReportsProps) {
+  const now = new Date();
+  const currentYear = now.getMonth() >= 3 ? now.getFullYear() : now.getFullYear() - 1;
+  const defaultTaxYear = `${currentYear}-${String((currentYear + 1) % 100).padStart(2, '0')}`;
+  const [taxYear, setTaxYear] = useState(defaultTaxYear);
+  const [summary, setSummary] = useState<TaxYearSummary | null>(null);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSummary = async (event: FormEvent) => {
+    event.preventDefault();
+    setStatus('loading');
+    setError(null);
+    try {
+      const url = new URL('/tax/summary', window.location.origin);
+      url.searchParams.set('auth', authToken);
+      url.searchParams.set('taxYear', taxYear);
+      const result = await fetchJson<TaxYearSummary>(url.toString());
+      setSummary(result);
+      setStatus('idle');
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : 'Failed to compute tax summary');
+    }
+  };
+
+  const matchCsv = useMemo(() => {
+    if (!summary) {
+      return [] as Array<Record<string, unknown>>;
+    }
+    return summary.matchLines.map((line) => ({
+      sellRef: line.sellRef,
+      asset: line.asset,
+      ts: line.ts,
+      rule: line.rule,
+      buyRef: line.buyRef ?? '',
+      qty: line.matchedQty,
+      proceeds: line.proceedsGBP,
+      allowable_cost: line.allowableCostGBP,
+      gain: line.gainGBP
+    }));
+  }, [summary]);
+
+  const disposalCsv = useMemo(() => {
+    if (!summary) {
+      return [] as Array<Record<string, unknown>>;
+    }
+    return summary.disposals.map((disposal) => ({
+      sellRef: disposal.sellRef,
+      ts: disposal.ts,
+      asset: disposal.asset,
+      quantity: disposal.quantity,
+      grossProceeds: disposal.grossProceedsGBP,
+      fees: disposal.disposalFeesGBP,
+      netProceeds: disposal.netProceedsGBP,
+      totalGain: disposal.totalGainGBP
+    }));
+  }, [summary]);
+
+  const totals = summary?.totals ?? { overallGainGBP: 0, byAsset: { ETH: 0, BTC: 0, USDT: 0 } };
+  const pools = summary?.pools ?? { ETH: { totalQty: 0, totalCostGBP: 0, avgCostGBP: 0 }, BTC: { totalQty: 0, totalCostGBP: 0, avgCostGBP: 0 }, USDT: { totalQty: 0, totalCostGBP: 0, avgCostGBP: 0 } };
+
+  return (
+    <section className="card p-4 space-y-4">
+      <form onSubmit={loadSummary} className="flex flex-wrap items-center gap-3 text-xs">
+        <label className="flex items-center gap-2">
+          Tax year (YYYY-YY)
+          <input value={taxYear} onChange={(event) => setTaxYear(event.target.value)} />
+        </label>
+        <button type="submit" className="bg-slate-700 hover:bg-slate-600">
+          Compute HMRC gains
+        </button>
+        {summary ? (
+          <>
+            <ExportCsvButton filename="tax-disposals.csv" rows={disposalCsv} />
+            <ExportCsvButton filename="tax-match-lines.csv" rows={matchCsv} />
+          </>
+        ) : null}
+      </form>
+      {status === 'loading' ? <p className="text-xs text-slate-400">Calculating…</p> : null}
+      {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+      {summary ? (
+        <div className="space-y-4 text-sm">
+          <section className="grid gap-3 md:grid-cols-3">
+            <div className="card p-3">
+              <h4 className="text-xs uppercase text-slate-400">Overall gain (GBP)</h4>
+              <p className="text-2xl font-mono">£{totals.overallGainGBP.toFixed(2)}</p>
+            </div>
+            {Object.entries(totals.byAsset).map(([asset, value]) => (
+              <div key={asset} className="card p-3">
+                <h4 className="text-xs uppercase text-slate-400">{asset} gain</h4>
+                <p className="text-2xl font-mono">£{value.toFixed(2)}</p>
+              </div>
+            ))}
+          </section>
+          <section className="space-y-2">
+            <h4 className="font-semibold">Section 104 closing pools</h4>
+            <div className="grid gap-3 md:grid-cols-3 text-xs">
+              {Object.entries(pools).map(([asset, pool]) => (
+                <div key={asset} className="card p-3 space-y-1">
+                  <div className="text-sm font-semibold">{asset}</div>
+                  <div>Quantity: {pool.totalQty.toFixed(6)}</div>
+                  <div>Total cost: £{pool.totalCostGBP.toFixed(2)}</div>
+                  <div>Avg cost: £{pool.avgCostGBP.toFixed(2)}</div>
+                </div>
+              ))}
+            </div>
+          </section>
+          <section className="space-y-2">
+            <h4 className="font-semibold">Disposals</h4>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-xs">
+                <thead className="bg-slate-900 text-slate-300">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Time</th>
+                    <th className="px-3 py-2 text-left">Asset</th>
+                    <th className="px-3 py-2 text-right">Qty</th>
+                    <th className="px-3 py-2 text-right">Gross</th>
+                    <th className="px-3 py-2 text-right">Fees</th>
+                    <th className="px-3 py-2 text-right">Net</th>
+                    <th className="px-3 py-2 text-right">Gain</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.disposals.map((disposal) => (
+                    <tr key={disposal.sellRef} className="odd:bg-slate-900/40">
+                      <td className="px-3 py-2 whitespace-nowrap">{new Date(disposal.ts).toLocaleString('en-GB', { hour12: false })}</td>
+                      <td className="px-3 py-2">{disposal.asset}</td>
+                      <td className="px-3 py-2 text-right font-mono">{disposal.quantity.toFixed(6)}</td>
+                      <td className="px-3 py-2 text-right font-mono">£{disposal.grossProceedsGBP.toFixed(2)}</td>
+                      <td className="px-3 py-2 text-right font-mono">£{disposal.disposalFeesGBP.toFixed(2)}</td>
+                      <td className="px-3 py-2 text-right font-mono">£{disposal.netProceedsGBP.toFixed(2)}</td>
+                      <td className="px-3 py-2 text-right font-mono text-emerald-400">£{disposal.totalGainGBP.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+          <section className="space-y-2 text-xs">
+            <h4 className="font-semibold">Match lines</h4>
+            <div className="overflow-x-auto max-h-64">
+              <table className="min-w-full">
+                <thead className="bg-slate-900 text-slate-300">
+                  <tr>
+                    <th className="px-3 py-2">Sell Ref</th>
+                    <th className="px-3 py-2">Rule</th>
+                    <th className="px-3 py-2">Qty</th>
+                    <th className="px-3 py-2">Proceeds</th>
+                    <th className="px-3 py-2">Allowable cost</th>
+                    <th className="px-3 py-2">Gain</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.matchLines.map((line) => (
+                    <tr key={`${line.sellRef}-${line.rule}-${line.buyRef ?? 'pool'}-${line.matchedQty}`} className="odd:bg-slate-900/40">
+                      <td className="px-3 py-2">{line.sellRef}</td>
+                      <td className="px-3 py-2">{line.rule}</td>
+                      <td className="px-3 py-2 text-right font-mono">{line.matchedQty.toFixed(6)}</td>
+                      <td className="px-3 py-2 text-right font-mono">£{line.proceedsGBP.toFixed(2)}</td>
+                      <td className="px-3 py-2 text-right font-mono">£{line.allowableCostGBP.toFixed(2)}</td>
+                      <td className="px-3 py-2 text-right font-mono text-emerald-400">£{line.gainGBP.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      ) : (
+        <p className="text-xs text-slate-400">Compute a tax year to view results. Not tax advice.</p>
+      )}
+    </section>
+  );
+}
+
+export default TaxReports;

--- a/svc-arbi-dash/app/src/components/TradesForm.tsx
+++ b/svc-arbi-dash/app/src/components/TradesForm.tsx
@@ -1,0 +1,180 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { useFrankfurter } from '../hooks/useFrankfurter';
+import { parseUkDateTime, toLondonDateTime } from '../lib/time';
+import { Trade, TradeSide, AssetSymbol, Money } from '../lib/types';
+
+interface TradesFormProps {
+  onSubmit: (payload: Partial<Trade> & { id?: string }) => Promise<void>;
+  editing?: Trade | null;
+  onCancelEdit?: () => void;
+}
+
+const ASSETS: AssetSymbol[] = ['ETH', 'BTC', 'USDT'];
+const SIDES: TradeSide[] = ['BUY', 'SELL'];
+
+const currencyOptions: Money['currency'][] = ['GBP', 'ZAR', 'ASSET'];
+
+export function TradesForm({ onSubmit, editing, onCancelEdit }: TradesFormProps) {
+  const { quotes } = useFrankfurter();
+  const [tsLocal, setTsLocal] = useState(() => new Date().toISOString().slice(0, 16));
+  const [asset, setAsset] = useState<AssetSymbol>('ETH');
+  const [side, setSide] = useState<TradeSide>('BUY');
+  const [quantity, setQuantity] = useState(0);
+  const [priceGBP, setPriceGBP] = useState<number | ''>('');
+  const [priceZAR, setPriceZAR] = useState<number | ''>('');
+  const [fx, setFx] = useState<number | ''>('');
+  const [venue, setVenue] = useState<'LUNO' | 'KRAKEN' | 'OTHER'>('LUNO');
+  const [feeAmount, setFeeAmount] = useState<number | ''>('');
+  const [feeCurrency, setFeeCurrency] = useState<Money['currency']>('GBP');
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (editing) {
+      const dt = toLondonDateTime(editing.ts);
+      setTsLocal(dt.toFormat("yyyy-LL-dd'T'HH:mm"));
+      setAsset(editing.asset);
+      setSide(editing.side);
+      setQuantity(editing.quantity);
+      setPriceGBP(editing.priceGBP ?? '');
+      setPriceZAR(editing.priceZAR ?? '');
+      setFx(editing.fx_gbp_zar ?? '');
+      setVenue(editing.venue ?? 'LUNO');
+      setFeeAmount(editing.fee?.amount ?? '');
+      setFeeCurrency(editing.fee?.currency ?? 'GBP');
+      setNotes(editing.notes ?? '');
+    }
+  }, [editing]);
+
+  useEffect(() => {
+    if (!priceGBP && priceZAR && !fx && quotes.GBPZAR) {
+      setFx(quotes.GBPZAR.rate);
+    }
+  }, [priceGBP, priceZAR, fx, quotes]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (!priceGBP && !(priceZAR && fx)) {
+        throw new Error('Provide GBP price or ZAR price with FX');
+      }
+      const ts = parseUkDateTime(tsLocal.replace('T', ' '));
+      const payload: Partial<Trade> & { id?: string } = {
+        id: editing?.id,
+        ts,
+        asset,
+        side,
+        quantity,
+        venue,
+        priceGBP: priceGBP === '' ? undefined : Number(priceGBP),
+        priceZAR: priceZAR === '' ? undefined : Number(priceZAR),
+        fx_gbp_zar: fx === '' ? undefined : Number(fx),
+        notes: notes || undefined
+      };
+      if (feeAmount !== '') {
+        payload.fee = { amount: Number(feeAmount), currency: feeCurrency };
+      }
+      await onSubmit(payload);
+      if (!editing) {
+        setQuantity(0);
+        setPriceGBP('');
+        setPriceZAR('');
+        setFx('');
+        setFeeAmount('');
+        setNotes('');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit trade');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="card p-4 space-y-3 text-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">{editing ? 'Edit trade' : 'New trade'}</h3>
+        {editing && onCancelEdit ? (
+          <button type="button" onClick={onCancelEdit} className="bg-slate-700 hover:bg-slate-600 text-xs">
+            Cancel edit
+          </button>
+        ) : null}
+      </div>
+      {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+      <div className="grid gap-2 md:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          Timestamp (UK)
+          <input type="datetime-local" value={tsLocal} onChange={(event) => setTsLocal(event.target.value)} />
+        </label>
+        <label className="flex flex-col gap-1">
+          Asset
+          <select value={asset} onChange={(event) => setAsset(event.target.value as AssetSymbol)}>
+            {ASSETS.map((item) => (
+              <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          Side
+          <select value={side} onChange={(event) => setSide(event.target.value as TradeSide)}>
+            {SIDES.map((item) => (
+              <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          Quantity
+          <input type="number" value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} />
+        </label>
+        <label className="flex flex-col gap-1">
+          Price GBP (optional)
+          <input type="number" value={priceGBP} onChange={(event) => setPriceGBP(event.target.value === '' ? '' : Number(event.target.value))} />
+        </label>
+        <label className="flex flex-col gap-1">
+          Price ZAR (optional)
+          <input type="number" value={priceZAR} onChange={(event) => setPriceZAR(event.target.value === '' ? '' : Number(event.target.value))} />
+        </label>
+        <label className="flex flex-col gap-1">
+          FX GBP→ZAR
+          <input type="number" value={fx} onChange={(event) => setFx(event.target.value === '' ? '' : Number(event.target.value))} />
+        </label>
+        <label className="flex flex-col gap-1">
+          Venue
+          <select value={venue} onChange={(event) => setVenue(event.target.value as typeof venue)}>
+            <option value="LUNO">Luno</option>
+            <option value="KRAKEN">Kraken</option>
+            <option value="OTHER">Other</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          Fee amount
+          <input type="number" value={feeAmount} onChange={(event) => setFeeAmount(event.target.value === '' ? '' : Number(event.target.value))} />
+        </label>
+        <label className="flex flex-col gap-1">
+          Fee currency
+          <select value={feeCurrency} onChange={(event) => setFeeCurrency(event.target.value as Money['currency'])}>
+            {currencyOptions.map((currency) => (
+              <option key={currency} value={currency}>
+                {currency}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 md:col-span-2">
+          Notes
+          <textarea value={notes} onChange={(event) => setNotes(event.target.value)} rows={2} />
+        </label>
+      </div>
+      <div className="flex items-center gap-3">
+        <button type="submit" className="bg-sky-600 hover:bg-sky-500 text-sm">
+          {editing ? 'Save trade' : 'Create trade'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default TradesForm;

--- a/svc-arbi-dash/app/src/components/TradesTable.tsx
+++ b/svc-arbi-dash/app/src/components/TradesTable.tsx
@@ -1,0 +1,196 @@
+import { useMemo, useState } from 'react';
+import { useTradesApi } from '../hooks/useTradesApi';
+import { formatDateTime, parseUkDate } from '../lib/time';
+import { Trade, AssetSymbol, TradeSide } from '../lib/types';
+import ExportCsvButton from './ExportCsvButton';
+
+interface TradesTableProps {
+  api: ReturnType<typeof useTradesApi>;
+  onEdit: (trade: Trade) => void;
+}
+
+const ASSETS: Array<'ALL' | AssetSymbol> = ['ALL', 'ETH', 'BTC', 'USDT'];
+const SIDES: Array<'ALL' | TradeSide> = ['ALL', 'BUY', 'SELL'];
+
+export function TradesTable({ api, onEdit }: TradesTableProps) {
+  const { trades, status, error, filters, setFilters, loadMore, hasMore, remove, lock, refresh } = api;
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const csvRows = useMemo(() => {
+    return trades.map((trade) => ({
+      id: trade.id,
+      ts_epoch: trade.ts,
+      ts_local: formatDateTime(trade.ts),
+      asset: trade.asset,
+      side: trade.side,
+      quantity: trade.quantity,
+      per_unit_gbp: trade.derived?.perUnitGBP ?? trade.priceGBP ?? '',
+      fx_gbp_zar: trade.fx_gbp_zar ?? '',
+      proceeds_gbp: trade.derived?.gbpProceedsOrCost ?? '',
+      fee_gbp: trade.derived?.feeGBP ?? '',
+      venue: trade.venue ?? '',
+      notes: trade.notes ?? '',
+      locked: trade.locked ?? false
+    }));
+  }, [trades]);
+
+  const toggleSelection = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <section className="card p-4 space-y-4">
+      <div className="flex flex-wrap items-center gap-3 text-xs">
+        <div className="flex items-center gap-2">
+          <label htmlFor="trade-asset">Asset</label>
+          <select
+            id="trade-asset"
+            value={filters.asset ?? 'ALL'}
+            onChange={(event) => setFilters((prev) => ({ ...prev, asset: event.target.value === 'ALL' ? undefined : (event.target.value as AssetSymbol) }))}
+            className="bg-slate-800 border border-slate-700 rounded px-2 py-1"
+          >
+            {ASSETS.map((asset) => (
+              <option key={asset} value={asset}>
+                {asset}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="trade-side">Side</label>
+          <select
+            id="trade-side"
+            value={filters.side ?? 'ALL'}
+            onChange={(event) => setFilters((prev) => ({ ...prev, side: event.target.value === 'ALL' ? undefined : (event.target.value as TradeSide) }))}
+            className="bg-slate-800 border border-slate-700 rounded px-2 py-1"
+          >
+            {SIDES.map((side) => (
+              <option key={side} value={side}>
+                {side}
+              </option>
+            ))}
+          </select>
+        </div>
+        <label className="flex items-center gap-2">
+          From
+          <input
+            type="date"
+            value={filters.from ? new Date(filters.from).toISOString().slice(0, 10) : ''}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, from: event.target.value ? parseUkDate(event.target.value) : undefined }))
+            }
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          To
+          <input
+            type="date"
+            value={filters.to ? new Date(filters.to).toISOString().slice(0, 10) : ''}
+            onChange={(event) =>
+              setFilters((prev) => ({ ...prev, to: event.target.value ? parseUkDate(event.target.value) : undefined }))
+            }
+          />
+        </label>
+        <button onClick={refresh} className="bg-slate-700 hover:bg-slate-600">
+          Refresh
+        </button>
+        <button
+          onClick={async () => {
+            await lock(Array.from(selected));
+            setSelected(new Set());
+          }}
+          className="bg-emerald-700 hover:bg-emerald-600"
+          disabled={selected.size === 0}
+        >
+          Lock selected
+        </button>
+        <ExportCsvButton filename="trades.csv" rows={csvRows} />
+      </div>
+      {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead className="bg-slate-900 text-slate-300">
+            <tr>
+              <th className="px-3 py-2 text-left">Select</th>
+              <th className="px-3 py-2 text-left">Time (UK)</th>
+              <th className="px-3 py-2 text-left">Asset</th>
+              <th className="px-3 py-2 text-left">Side</th>
+              <th className="px-3 py-2 text-right">Qty</th>
+              <th className="px-3 py-2 text-right">GBP</th>
+              <th className="px-3 py-2 text-right">ZAR</th>
+              <th className="px-3 py-2 text-right">FX</th>
+              <th className="px-3 py-2 text-right">GBP proceeds</th>
+              <th className="px-3 py-2 text-right">Fee GBP</th>
+              <th className="px-3 py-2 text-left">Venue</th>
+              <th className="px-3 py-2 text-left">Notes</th>
+              <th className="px-3 py-2 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {trades.map((trade) => (
+              <tr key={trade.id} className={`odd:bg-slate-900/40 ${trade.locked ? 'opacity-60' : ''}`}>
+                <td className="px-3 py-2">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(trade.id)}
+                    onChange={() => toggleSelection(trade.id)}
+                    disabled={trade.locked}
+                  />
+                </td>
+                <td className="px-3 py-2 whitespace-nowrap">{formatDateTime(trade.ts)}</td>
+                <td className="px-3 py-2">{trade.asset}</td>
+                <td className="px-3 py-2">{trade.side}</td>
+                <td className="px-3 py-2 text-right font-mono">{trade.quantity.toFixed(6)}</td>
+                <td className="px-3 py-2 text-right font-mono">{trade.priceGBP ?? '—'}</td>
+                <td className="px-3 py-2 text-right font-mono">{trade.priceZAR ?? '—'}</td>
+                <td className="px-3 py-2 text-right font-mono">{trade.fx_gbp_zar ?? '—'}</td>
+                <td className="px-3 py-2 text-right font-mono">{trade.derived?.gbpProceedsOrCost?.toFixed(2) ?? '—'}</td>
+                <td className="px-3 py-2 text-right font-mono">{trade.derived?.feeGBP?.toFixed(2) ?? '—'}</td>
+                <td className="px-3 py-2">{trade.venue ?? '—'}</td>
+                <td className="px-3 py-2 max-w-xs truncate" title={trade.notes ?? ''}>
+                  {trade.notes ?? '—'}
+                </td>
+                <td className="px-3 py-2 space-x-2">
+                  <button
+                    className="bg-slate-700 hover:bg-slate-600"
+                    onClick={() => onEdit(trade)}
+                    disabled={trade.locked}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="bg-rose-700 hover:bg-rose-600"
+                    onClick={() => remove(trade.id)}
+                    disabled={trade.locked}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex items-center gap-3 text-xs">
+        <span>Status: {status}</span>
+        {hasMore ? (
+          <button onClick={loadMore} className="bg-slate-700 hover:bg-slate-600">
+            Load more
+          </button>
+        ) : (
+          <span>No more trades</span>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default TradesTable;

--- a/svc-arbi-dash/app/src/hooks/useDataWindow.ts
+++ b/svc-arbi-dash/app/src/hooks/useDataWindow.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Page, Sample } from '../lib/types';
+
+const PAGE_LIMIT = 250;
+
+type Status = 'idle' | 'loading' | 'ready' | 'error';
+
+type UseDataWindowOptions = {
+  authToken: string;
+  historyHours: number;
+  autoRefreshMs: number;
+};
+
+async function fetchSamples(authToken: string, cursor: string | null, limit: number): Promise<Page> {
+  const url = new URL('/data', window.location.origin);
+  url.searchParams.set('auth', authToken);
+  url.searchParams.set('limit', String(limit));
+  if (cursor) {
+    url.searchParams.set('cursor', cursor);
+  }
+  const res = await fetch(url.toString(), {
+    headers: {
+      'Cache-Control': 'no-store'
+    }
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch samples (${res.status})`);
+  }
+  return (await res.json()) as Page;
+}
+
+function mergeSamples(existing: Sample[], incoming: Sample[]): Sample[] {
+  const map = new Map<number, Sample>();
+  for (const sample of existing) {
+    map.set(sample.ts, sample);
+  }
+  for (const sample of incoming) {
+    map.set(sample.ts, sample);
+  }
+  return Array.from(map.values()).sort((a, b) => a.ts - b.ts);
+}
+
+export function useDataWindow({ authToken, historyHours, autoRefreshMs }: UseDataWindowOptions) {
+  const [samples, setSamples] = useState<Sample[]>([]);
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const refreshTimer = useRef<number | null>(null);
+  const loadingMore = useRef(false);
+
+  const loadInitial = useCallback(async () => {
+    if (!authToken) {
+      return;
+    }
+    setStatus('loading');
+    setError(null);
+    const cutoff = Date.now() - historyHours * 60 * 60 * 1000;
+    let cursor: string | null = null;
+    let accumulated: Sample[] = [];
+    try {
+      while (true) {
+        const page = await fetchSamples(authToken, cursor, PAGE_LIMIT);
+        accumulated = mergeSamples(accumulated, page.samples);
+        cursor = page.nextCursor;
+        if (!cursor) {
+          setNextCursor(null);
+          break;
+        }
+        const oldest = accumulated[0]?.ts ?? Infinity;
+        if (oldest <= cutoff) {
+          setNextCursor(cursor);
+          break;
+        }
+      }
+      setSamples(accumulated);
+      setStatus('ready');
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    }
+  }, [authToken, historyHours]);
+
+  const refresh = useCallback(async () => {
+    if (!authToken) {
+      return;
+    }
+    try {
+      const page = await fetchSamples(authToken, null, Math.max(50, PAGE_LIMIT / 2));
+      setSamples((prev) => mergeSamples(prev, page.samples));
+      setNextCursor((prevCursor) => prevCursor ?? page.nextCursor ?? null);
+      setStatus('ready');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      setStatus('error');
+    }
+  }, [authToken]);
+
+  const loadMore = useCallback(async () => {
+    if (!authToken || !nextCursor || loadingMore.current) {
+      return;
+    }
+    loadingMore.current = true;
+    try {
+      const page = await fetchSamples(authToken, nextCursor, PAGE_LIMIT);
+      setSamples((prev) => mergeSamples(prev, page.samples));
+      setNextCursor(page.nextCursor);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      loadingMore.current = false;
+    }
+  }, [authToken, nextCursor]);
+
+  useEffect(() => {
+    void loadInitial();
+  }, [loadInitial]);
+
+  useEffect(() => {
+    if (refreshTimer.current) {
+      window.clearInterval(refreshTimer.current);
+    }
+    refreshTimer.current = window.setInterval(() => {
+      void refresh();
+    }, autoRefreshMs);
+    return () => {
+      if (refreshTimer.current) {
+        window.clearInterval(refreshTimer.current);
+      }
+    };
+  }, [autoRefreshMs, refresh]);
+
+  const state = useMemo(
+    () => ({ samples, status, error, refresh, loadMore, hasMore: Boolean(nextCursor) }),
+    [samples, status, error, refresh, loadMore, nextCursor]
+  );
+
+  return state;
+}

--- a/svc-arbi-dash/app/src/hooks/useFrankfurter.ts
+++ b/svc-arbi-dash/app/src/hooks/useFrankfurter.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FrankfurterQuote } from '../lib/fx';
+
+const CACHE_MS = 60_000;
+
+export type QuoteKey = 'GBPZAR' | 'USDZAR';
+
+export type FxQuote = {
+  pair: QuoteKey;
+  rate: number;
+  fetchedAt: number;
+};
+
+async function fetchQuote(base: string, symbol: string): Promise<FxQuote> {
+  const res = await fetch(`https://api.frankfurter.app/latest?from=${base}&to=${symbol}`);
+  if (!res.ok) {
+    throw new Error(`Frankfurter request failed: ${res.status}`);
+  }
+  const payload = (await res.json()) as FrankfurterQuote;
+  const rate = payload.rates[symbol];
+  return {
+    pair: `${base}${symbol}` as QuoteKey,
+    rate,
+    fetchedAt: Date.now()
+  };
+}
+
+export function useFrankfurter() {
+  const [quotes, setQuotes] = useState<Record<QuoteKey, FxQuote | null>>({ GBPZAR: null, USDZAR: null });
+  const quotesRef = useRef(quotes);
+  const [error, setError] = useState<string | null>(null);
+  const pending = useRef<Promise<void> | null>(null);
+
+  const load = useCallback(async () => {
+    if (pending.current) {
+      return pending.current;
+    }
+    const task = (async () => {
+      try {
+        const [gbp, usd] = await Promise.all([fetchQuote('GBP', 'ZAR'), fetchQuote('USD', 'ZAR')]);
+        const next = { GBPZAR: gbp, USDZAR: usd } as Record<QuoteKey, FxQuote>;
+        quotesRef.current = next;
+        setQuotes(next);
+        setError(null);
+      } catch (err) {
+        console.error(err);
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        pending.current = null;
+      }
+    })();
+    pending.current = task;
+    await task;
+  }, []);
+
+  useEffect(() => {
+    void load();
+    const id = window.setInterval(() => {
+      const now = Date.now();
+      const stale = Object.values(quotesRef.current).some((quote) => !quote || now - quote.fetchedAt > CACHE_MS);
+      if (stale) {
+        void load();
+      }
+    }, 15_000);
+    return () => window.clearInterval(id);
+  }, [load]);
+
+  const refresh = useCallback(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    quotesRef.current = quotes;
+  }, [quotes]);
+
+  const latest = useMemo(() => quotes, [quotes]);
+
+  return { quotes: latest, error, refresh };
+}

--- a/svc-arbi-dash/app/src/hooks/useLocalSettings.ts
+++ b/svc-arbi-dash/app/src/hooks/useLocalSettings.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AssetSymbol } from '../lib/types';
+
+type FeeSide = {
+  taker: number;
+  maker: number;
+};
+
+type FeeTable = Record<AssetSymbol, FeeSide>;
+
+type WithdrawalFees = Record<AssetSymbol, { luno: number; kraken: number }>;
+
+type SlippageCaps = Record<AssetSymbol, number>;
+
+type Profiles = Record<
+  'Conservative' | 'Realistic' | 'Aggressive',
+  { slippageMultiplier: number; withdrawalAmortization: boolean }
+>;
+
+export type LocalSettings = {
+  historyHours: number;
+  autoRefreshMs: number;
+  fees: {
+    luno: FeeTable;
+    kraken: FeeTable;
+  };
+  withdrawalFees: WithdrawalFees;
+  slippageCaps: SlippageCaps;
+  balances: { lunoZAR: number; krakenGBP: number };
+  withdrawalAmortization: boolean;
+  profile: keyof Profiles;
+};
+
+const STORAGE_KEY = 'svc-arbi-dash::settings';
+
+const DEFAULT_SETTINGS: LocalSettings = {
+  historyHours: 24,
+  autoRefreshMs: 60_000,
+  fees: {
+    luno: {
+      USDT: { taker: 0.2, maker: -0.01 },
+      ETH: { taker: 0.6, maker: 0.4 },
+      BTC: { taker: 0.6, maker: 0.4 }
+    },
+    kraken: {
+      USDT: { taker: 0.2, maker: 0.2 },
+      ETH: { taker: 0.4, maker: 0.25 },
+      BTC: { taker: 0.4, maker: 0.25 }
+    }
+  },
+  withdrawalFees: {
+    BTC: { luno: 0.00006, kraken: 0.0002 },
+    ETH: { luno: 0.003, kraken: 0.003 },
+    USDT: { luno: 15, kraken: 15 }
+  },
+  slippageCaps: {
+    ETH: 0.1,
+    BTC: 0.1,
+    USDT: 0.05
+  },
+  balances: { lunoZAR: 100_000, krakenGBP: 5_000 },
+  withdrawalAmortization: false,
+  profile: 'Realistic'
+};
+
+const PROFILES: Profiles = {
+  Conservative: { slippageMultiplier: 1.5, withdrawalAmortization: true },
+  Realistic: { slippageMultiplier: 1, withdrawalAmortization: false },
+  Aggressive: { slippageMultiplier: 0.7, withdrawalAmortization: false }
+};
+
+export function useLocalSettings() {
+  const [settings, setSettings] = useState<LocalSettings>(DEFAULT_SETTINGS);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as LocalSettings;
+        setSettings({ ...DEFAULT_SETTINGS, ...parsed });
+      }
+    } catch (err) {
+      console.warn('Failed to load settings', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    } catch (err) {
+      console.warn('Failed to persist settings', err);
+    }
+  }, [settings]);
+
+  const update = useCallback(
+    (patch: Partial<LocalSettings>) => {
+      setSettings((prev) => ({ ...prev, ...patch }));
+    },
+    []
+  );
+
+  const applyProfile = useCallback(
+    (profile: keyof Profiles) => {
+      const profileConfig = PROFILES[profile];
+      setSettings((prev) => ({
+        ...prev,
+        profile,
+        withdrawalAmortization: profileConfig.withdrawalAmortization,
+        slippageCaps: Object.fromEntries(
+          Object.entries(prev.slippageCaps).map(([asset, value]) => [asset, value * profileConfig.slippageMultiplier])
+        ) as SlippageCaps
+      }));
+    },
+    []
+  );
+
+  const reset = useCallback(() => {
+    setSettings(DEFAULT_SETTINGS);
+  }, []);
+
+  const exportProfile = useCallback(() => {
+    const blob = new Blob([JSON.stringify(settings, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'svc-arbi-dash-settings.json';
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }, [settings]);
+
+  const importProfile = useCallback(async (file: File) => {
+    const text = await file.text();
+    const parsed = JSON.parse(text) as Partial<LocalSettings>;
+    setSettings((prev) => ({ ...prev, ...parsed }));
+  }, []);
+
+  return useMemo(
+    () => ({ settings, setSettings, update, reset, applyProfile, exportProfile, importProfile, profiles: PROFILES }),
+    [settings, update, reset, applyProfile, exportProfile, importProfile]
+  );
+}

--- a/svc-arbi-dash/app/src/hooks/useTradesApi.ts
+++ b/svc-arbi-dash/app/src/hooks/useTradesApi.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Trade, TradeFilters, TradeListResponse } from '../lib/types';
+
+const DEFAULT_LIMIT = 100;
+
+type TradeApiState = {
+  trades: Trade[];
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  error: string | null;
+  hasMore: boolean;
+};
+
+type TradeMutationPayload = Omit<Trade, 'id' | 'derived' | 'locked'> & { id?: string };
+
+function buildQuery(filters: TradeFilters, limit: number, cursor: string | null, authToken: string): string {
+  const url = new URL('/trades', window.location.origin);
+  url.searchParams.set('auth', authToken);
+  url.searchParams.set('limit', String(limit));
+  if (cursor) {
+    url.searchParams.set('cursor', cursor);
+  }
+  if (filters.asset) {
+    url.searchParams.set('asset', filters.asset);
+  }
+  if (filters.side) {
+    url.searchParams.set('side', filters.side);
+  }
+  if (filters.from) {
+    url.searchParams.set('from', String(filters.from));
+  }
+  if (filters.to) {
+    url.searchParams.set('to', String(filters.to));
+  }
+  return url.toString();
+}
+
+async function jsonFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {})
+    }
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed with ${res.status}`);
+  }
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+}
+
+export function useTradesApi(authToken: string) {
+  const [state, setState] = useState<TradeApiState>({ trades: [], status: 'idle', error: null, hasMore: false });
+  const [filters, setFilters] = useState<TradeFilters>({});
+  const [cursor, setCursor] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (reset = false) => {
+      if (!authToken) {
+        return;
+      }
+      setState((prev) => ({ ...prev, status: 'loading', error: null }));
+      try {
+        const url = buildQuery(filters, DEFAULT_LIMIT, reset ? null : cursor, authToken);
+        const page = await jsonFetch<TradeListResponse>(url);
+        setState((prev) => ({
+          trades: reset ? page.trades : [...prev.trades, ...page.trades],
+          status: 'ready',
+          error: null,
+          hasMore: Boolean(page.nextCursor)
+        }));
+        setCursor(page.nextCursor);
+      } catch (err) {
+        setState((prev) => ({ ...prev, status: 'error', error: err instanceof Error ? err.message : 'Unknown error' }));
+      }
+    },
+    [authToken, filters, cursor]
+  );
+
+  useEffect(() => {
+    void load(true);
+  }, [load, filters]);
+
+  const refresh = useCallback(() => load(true), [load]);
+
+  const loadMore = useCallback(() => load(false), [load]);
+
+  const mutate = useCallback(
+    async (method: 'POST' | 'PUT', payload: TradeMutationPayload) => {
+      const targetUrl = new URL('/trades', window.location.origin);
+      targetUrl.searchParams.set('auth', authToken);
+      let url = targetUrl.toString();
+      if (method === 'PUT' && payload.id) {
+        url = new URL(`/trades/${payload.id}`, window.location.origin).toString();
+        url += `?auth=${encodeURIComponent(authToken)}`;
+      }
+      await jsonFetch<Trade>(url, {
+        method,
+        body: JSON.stringify(payload)
+      });
+      await refresh();
+    },
+    [authToken, refresh]
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      const url = new URL(`/trades/${id}`, window.location.origin);
+      url.searchParams.set('auth', authToken);
+      await jsonFetch<void>(url.toString(), { method: 'DELETE' });
+      await refresh();
+    },
+    [authToken, refresh]
+  );
+
+  const lock = useCallback(
+    async (ids: string[]) => {
+      const url = new URL('/trades/lock', window.location.origin);
+      url.searchParams.set('auth', authToken);
+      await jsonFetch<void>(url.toString(), { method: 'POST', body: JSON.stringify({ ids }) });
+      await refresh();
+    },
+    [authToken, refresh]
+  );
+
+  const read = useCallback(
+    async (id: string) => {
+      const url = new URL(`/trades/${id}`, window.location.origin);
+      url.searchParams.set('auth', authToken);
+      return jsonFetch<Trade>(url.toString());
+    },
+    [authToken]
+  );
+
+  return useMemo(
+    () => ({
+      ...state,
+      filters,
+      setFilters,
+      refresh,
+      loadMore,
+      create: (payload: TradeMutationPayload) => mutate('POST', payload),
+      update: (payload: TradeMutationPayload) => mutate('PUT', payload),
+      remove,
+      lock,
+      read
+    }),
+    [state, filters, refresh, loadMore, mutate, remove, lock, read]
+  );
+}

--- a/svc-arbi-dash/app/src/lib/calc.ts
+++ b/svc-arbi-dash/app/src/lib/calc.ts
@@ -1,0 +1,102 @@
+import { AssetSymbol } from './types';
+
+export type TradeLegCost = {
+  feePct?: number;
+  slippagePct?: number;
+};
+
+export type EffectiveParams = {
+  nominalPct: number;
+  legs: TradeLegCost[];
+  withdrawalPct?: number;
+};
+
+export function effectiveArbPercentage({ nominalPct, legs, withdrawalPct = 0 }: EffectiveParams): number {
+  const legCost = legs.reduce((acc, leg) => acc + (leg.feePct ?? 0) + (leg.slippagePct ?? 0), 0);
+  return nominalPct - legCost - withdrawalPct;
+}
+
+export function slippageDeduction(legs: TradeLegCost[]): number {
+  return legs.reduce((acc, leg) => acc + (leg.slippagePct ?? 0), 0);
+}
+
+export function withdrawalAmortizationPct(withdrawalFeeAsset: number, assetPriceGBP: number, notionalGBP: number): number {
+  if (notionalGBP <= 0) {
+    return 0;
+  }
+  const feeGBP = withdrawalFeeAsset * assetPriceGBP;
+  return (feeGBP / notionalGBP) * 100;
+}
+
+export function percentageDifference(v1: number, v2: number): {
+  absolute: number;
+  relativePct: number | null;
+  percentagePoints: number | null;
+} {
+  const absolute = v2 - v1;
+  const relativePct = v1 === 0 ? null : (absolute / Math.abs(v1)) * 100;
+  const percentagePoints = Number.isFinite(v1) && Number.isFinite(v2) ? v2 - v1 : null;
+  return { absolute, relativePct, percentagePoints };
+}
+
+export type PositionSizerInput = {
+  direction: 'KRAKEN_TO_LUNO' | 'LUNO_TO_KRAKEN';
+  asset: AssetSymbol;
+  balances: { lunoZAR: number; krakenGBP: number };
+  caps: { lunoZAR: number; krakenGBP: number };
+  prices: {
+    krakenAskGBP?: number | null;
+    krakenBidGBP?: number | null;
+    lunoAskZAR?: number | null;
+    lunoBidZAR?: number | null;
+    fxGBPZAR: number;
+  };
+  effectivePct: number;
+};
+
+export type PositionSizerResult = {
+  maxQty: number;
+  maxNotionalGBP: number;
+  maxNotionalZAR: number;
+  estimatedPnlGBP: number;
+};
+
+export function computePositionSize(input: PositionSizerInput): PositionSizerResult | null {
+  const { direction, balances, caps, prices, effectivePct } = input;
+  const lunoCapZAR = Math.min(balances.lunoZAR, caps.lunoZAR);
+  const krakenCapGBP = Math.min(balances.krakenGBP, caps.krakenGBP);
+  if (direction === 'KRAKEN_TO_LUNO') {
+    if (!prices.krakenAskGBP || !prices.lunoBidZAR) {
+      return null;
+    }
+    const maxQtyByKraken = krakenCapGBP / prices.krakenAskGBP;
+    const maxQtyByLuno = lunoCapZAR / prices.lunoBidZAR;
+    const maxQty = Math.max(0, Math.min(maxQtyByKraken, maxQtyByLuno));
+    const maxNotionalGBP = maxQty * prices.krakenAskGBP;
+    const maxNotionalZAR = maxNotionalGBP * prices.fxGBPZAR;
+    const estimatedPnlGBP = (maxNotionalGBP * effectivePct) / 100;
+    return { maxQty, maxNotionalGBP, maxNotionalZAR, estimatedPnlGBP };
+  }
+  if (!prices.lunoAskZAR || !prices.krakenBidGBP) {
+    return null;
+  }
+  const maxQtyByLuno = lunoCapZAR / prices.lunoAskZAR;
+  const maxQtyByKraken = krakenCapGBP / prices.krakenBidGBP;
+  const maxQty = Math.max(0, Math.min(maxQtyByLuno, maxQtyByKraken));
+  const maxNotionalGBP = maxQty * prices.krakenBidGBP;
+  const maxNotionalZAR = maxNotionalGBP * prices.fxGBPZAR;
+  const estimatedPnlGBP = (maxNotionalGBP * effectivePct) / 100;
+  return { maxQty, maxNotionalGBP, maxNotionalZAR, estimatedPnlGBP };
+}
+
+export function guardNumber(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return null;
+  }
+  return value;
+}
+
+export function round(value: number, decimals = 4): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}

--- a/svc-arbi-dash/app/src/lib/csv.ts
+++ b/svc-arbi-dash/app/src/lib/csv.ts
@@ -1,0 +1,28 @@
+export function toCsv<T extends Record<string, unknown>>(headers: string[], rows: T[]): string {
+  const escape = (value: unknown): string => {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    const str = String(value);
+    if (/[",\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+  const headerRow = headers.join(',');
+  const body = rows.map((row) => headers.map((key) => escape(row[key])).join(',')).join('\n');
+  return `${headerRow}\n${body}`;
+}
+
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}

--- a/svc-arbi-dash/app/src/lib/fx.ts
+++ b/svc-arbi-dash/app/src/lib/fx.ts
@@ -1,0 +1,28 @@
+export function convertGBPToZAR(amount: number, fx: number): number {
+  return amount * fx;
+}
+
+export function convertZARToGBP(amount: number, fx: number): number {
+  if (fx === 0) {
+    throw new Error('FX rate must be non-zero');
+  }
+  return amount / fx;
+}
+
+export function convertZARToUSD(amount: number, zarUsd: number): number {
+  if (zarUsd === 0) {
+    throw new Error('FX rate must be non-zero');
+  }
+  return amount / zarUsd;
+}
+
+export function convertUSDToZAR(amount: number, zarUsd: number): number {
+  return amount * zarUsd;
+}
+
+export type FrankfurterQuote = {
+  amount: number;
+  base: string;
+  date: string;
+  rates: Record<string, number>;
+};

--- a/svc-arbi-dash/app/src/lib/hmrc.ts
+++ b/svc-arbi-dash/app/src/lib/hmrc.ts
@@ -1,0 +1,302 @@
+import { DateTime } from 'luxon';
+import { AssetSymbol, DisposalReport, FlatMatchLine, MatchLine, MatchRule, Trade } from './types';
+import { LONDON_TZ, ukDayKey } from './time';
+
+const DAY_DIFF_LIMIT = 30;
+
+type PoolState = {
+  totalQty: number;
+  totalCostGBP: number;
+};
+
+type EnrichedTrade = Trade & {
+  remainingQty: number;
+  perUnitGBP: number;
+  netProceedsPerUnit?: number;
+  grossProceedsGBP?: number;
+  netProceedsGBP?: number;
+  disposalFeesGBP?: number;
+  totalCostPerUnit?: number;
+  acquisitionCostGBP?: number;
+  matches: MatchLine[];
+  issues: string[];
+};
+
+export type HmrcComputation = {
+  disposals: DisposalReport[];
+  matchLines: FlatMatchLine[];
+  pools: Record<AssetSymbol, { totalQty: number; totalCostGBP: number; avgCostGBP: number }>;
+  totals: { overallGainGBP: number; byAsset: Record<AssetSymbol, number> };
+  issues: string[];
+};
+
+export type HmrcComputationOptions = {
+  windowStart?: number;
+  windowEnd?: number;
+  poolSnapshotAt?: number;
+};
+
+function clonePoolState(map: Map<AssetSymbol, PoolState>): Record<AssetSymbol, PoolState & { avgCostGBP: number }> {
+  const result: Record<AssetSymbol, PoolState & { avgCostGBP: number }> = {
+    BTC: { totalQty: 0, totalCostGBP: 0, avgCostGBP: 0 },
+    ETH: { totalQty: 0, totalCostGBP: 0, avgCostGBP: 0 },
+    USDT: { totalQty: 0, totalCostGBP: 0, avgCostGBP: 0 }
+  };
+  for (const [asset, state] of map) {
+    const avgCost = state.totalQty > 0 ? state.totalCostGBP / state.totalQty : 0;
+    result[asset] = {
+      totalQty: state.totalQty,
+      totalCostGBP: state.totalCostGBP,
+      avgCostGBP: avgCost
+    };
+  }
+  return result;
+}
+
+function ensureEnriched(trade: Trade): EnrichedTrade {
+  if (!trade.derived) {
+    throw new Error(`Trade ${trade.id} missing derived values`);
+  }
+  const perUnit = trade.derived.perUnitGBP;
+  if (!Number.isFinite(perUnit)) {
+    throw new Error(`Trade ${trade.id} missing per-unit GBP`);
+  }
+  const base: EnrichedTrade = {
+    ...trade,
+    remainingQty: trade.quantity,
+    perUnitGBP: perUnit,
+    matches: [],
+    issues: []
+  };
+  if (trade.side === 'BUY') {
+    const fee = trade.derived.feeGBP ?? 0;
+    const acquisitionCost = trade.derived.gbpProceedsOrCost + fee;
+    const perUnitCost = acquisitionCost / trade.quantity;
+    base.acquisitionCostGBP = acquisitionCost;
+    base.totalCostPerUnit = perUnitCost;
+  } else {
+    const fee = trade.derived.feeGBP ?? 0;
+    const gross = trade.derived.gbpProceedsOrCost;
+    const net = gross - fee;
+    base.disposalFeesGBP = fee;
+    base.grossProceedsGBP = gross;
+    base.netProceedsGBP = net;
+    base.netProceedsPerUnit = net / trade.quantity;
+  }
+  return base;
+}
+
+function applyMatch(
+  sell: EnrichedTrade,
+  qty: number,
+  rule: MatchRule,
+  allowableCostGBP: number,
+  buy?: EnrichedTrade
+): void {
+  if (qty <= 0) {
+    return;
+  }
+  if (!sell.netProceedsPerUnit) {
+    throw new Error(`Sell trade ${sell.id} missing net proceeds`);
+  }
+  const proceeds = sell.netProceedsPerUnit * qty;
+  const gain = proceeds - allowableCostGBP;
+  const match: MatchLine = {
+    rule,
+    buyRef: buy?.id,
+    matchedQty: qty,
+    proceedsGBP: proceeds,
+    allowableCostGBP,
+    gainGBP: gain
+  };
+  sell.matches.push(match);
+  sell.remainingQty = Math.max(0, sell.remainingQty - qty);
+  if (buy) {
+    buy.remainingQty = Math.max(0, buy.remainingQty - qty);
+  }
+}
+
+function matchSameDay(byAsset: Map<AssetSymbol, EnrichedTrade[]>): void {
+  for (const [asset, trades] of byAsset) {
+    const buysByDay = new Map<string, EnrichedTrade[]>();
+    const sellsByDay = new Map<string, EnrichedTrade[]>();
+    trades
+      .filter((t) => t.side === 'BUY')
+      .forEach((buy) => {
+        const day = ukDayKey(buy.ts);
+        const arr = buysByDay.get(day) ?? [];
+        arr.push(buy);
+        buysByDay.set(day, arr);
+      });
+    trades
+      .filter((t) => t.side === 'SELL')
+      .forEach((sell) => {
+        const day = ukDayKey(sell.ts);
+        const arr = sellsByDay.get(day) ?? [];
+        arr.push(sell);
+        sellsByDay.set(day, arr);
+      });
+    for (const [day, sells] of sellsByDay) {
+      const buys = (buysByDay.get(day) ?? []).sort((a, b) => a.ts - b.ts);
+      sells.sort((a, b) => a.ts - b.ts);
+      for (const sell of sells) {
+        for (const buy of buys) {
+          if (sell.remainingQty <= 0) {
+            break;
+          }
+          if (buy.remainingQty <= 0) {
+            continue;
+          }
+          const qty = Math.min(sell.remainingQty, buy.remainingQty);
+          const allowable = qty * (buy.totalCostPerUnit ?? buy.perUnitGBP);
+          applyMatch(sell, qty, 'SAME_DAY', allowable, buy);
+        }
+      }
+    }
+  }
+}
+
+function dayDiff(sell: EnrichedTrade, buy: EnrichedTrade): number {
+  const sellDay = DateTime.fromMillis(sell.ts, { zone: LONDON_TZ }).startOf('day');
+  const buyDay = DateTime.fromMillis(buy.ts, { zone: LONDON_TZ }).startOf('day');
+  return Math.floor(buyDay.diff(sellDay, 'days').days);
+}
+
+function matchThirtyDay(byAsset: Map<AssetSymbol, EnrichedTrade[]>): void {
+  for (const trades of byAsset.values()) {
+    const sells = trades.filter((t) => t.side === 'SELL').sort((a, b) => a.ts - b.ts);
+    const buys = trades.filter((t) => t.side === 'BUY').sort((a, b) => a.ts - b.ts);
+    for (const sell of sells) {
+      if (sell.remainingQty <= 0) {
+        continue;
+      }
+      for (const buy of buys) {
+        if (buy.remainingQty <= 0) {
+          continue;
+        }
+        if (buy.ts <= sell.ts) {
+          continue;
+        }
+        const diff = dayDiff(sell, buy);
+        if (diff <= 0 || diff > DAY_DIFF_LIMIT) {
+          continue;
+        }
+        const qty = Math.min(sell.remainingQty, buy.remainingQty);
+        const allowable = qty * (buy.totalCostPerUnit ?? buy.perUnitGBP);
+        applyMatch(sell, qty, 'WITHIN_30_DAYS', allowable, buy);
+        if (sell.remainingQty <= 0) {
+          break;
+        }
+      }
+    }
+  }
+}
+
+export function computeHmrc(trades: Trade[], options: HmrcFinalOptions = {}): HmrcComputation {
+  const enrichedTrades = trades.map(ensureEnriched);
+  const byAsset = new Map<AssetSymbol, EnrichedTrade[]>();
+  for (const trade of enrichedTrades) {
+    const arr = byAsset.get(trade.asset) ?? [];
+    arr.push(trade);
+    byAsset.set(trade.asset, arr);
+  }
+  for (const tradesArr of byAsset.values()) {
+    tradesArr.sort((a, b) => a.ts - b.ts);
+  }
+  matchSameDay(byAsset);
+  matchThirtyDay(byAsset);
+
+  const pools = new Map<AssetSymbol, PoolState>([
+    ['BTC', { totalQty: 0, totalCostGBP: 0 }],
+    ['ETH', { totalQty: 0, totalCostGBP: 0 }],
+    ['USDT', { totalQty: 0, totalCostGBP: 0 }]
+  ]);
+
+  const chronological = [...enrichedTrades].sort((a, b) => a.ts - b.ts);
+  let closingSnapshot: Record<AssetSymbol, { totalQty: number; totalCostGBP: number; avgCostGBP: number }> | null = null;
+  const snapshotAt = options.poolSnapshotAt;
+
+  for (const trade of chronological) {
+    const pool = pools.get(trade.asset)!;
+    if (trade.side === 'BUY') {
+      const qty = trade.remainingQty;
+      if (qty > 0) {
+        const cost = qty * (trade.totalCostPerUnit ?? trade.perUnitGBP);
+        pool.totalQty += qty;
+        pool.totalCostGBP += cost;
+        trade.remainingQty = 0;
+      }
+    } else {
+      if (trade.remainingQty > 0) {
+        const qty = trade.remainingQty;
+        const availableQty = pool.totalQty;
+        const avgCost = availableQty > 0 ? pool.totalCostGBP / availableQty : 0;
+        const matched = Math.min(qty, availableQty);
+        if (matched > 0) {
+          const allowable = matched * avgCost;
+          applyMatch(trade, matched, 'SECTION_104', allowable);
+          pool.totalQty -= matched;
+          pool.totalCostGBP -= allowable;
+        }
+        const remainder = trade.remainingQty;
+        if (remainder > 0.0000001) {
+          applyMatch(trade, remainder, 'SECTION_104', 0);
+          trade.issues.push('Section 104 pool exhausted for portion of disposal');
+          trade.remainingQty = 0;
+        }
+      }
+    }
+    if (snapshotAt !== undefined && trade.ts <= snapshotAt) {
+      closingSnapshot = clonePoolState(pools);
+    }
+  }
+  if (!closingSnapshot) {
+    closingSnapshot = clonePoolState(pools);
+  }
+
+  const windowStart = options.windowStart ?? -Infinity;
+  const windowEnd = options.windowEnd ?? Infinity;
+  const disposals: DisposalReport[] = [];
+  const matchLines: FlatMatchLine[] = [];
+  const totalsByAsset: Record<AssetSymbol, number> = { BTC: 0, ETH: 0, USDT: 0 };
+  const issues: string[] = [];
+
+  for (const trade of enrichedTrades) {
+    if (trade.side !== 'SELL') {
+      continue;
+    }
+    const report: DisposalReport = {
+      sellRef: trade.id,
+      ts: trade.ts,
+      asset: trade.asset,
+      quantity: trade.quantity,
+      grossProceedsGBP: trade.grossProceedsGBP ?? 0,
+      disposalFeesGBP: trade.disposalFeesGBP ?? 0,
+      netProceedsGBP: trade.netProceedsGBP ?? 0,
+      matches: trade.matches,
+      totalGainGBP: trade.matches.reduce((acc, m) => acc + m.gainGBP, 0),
+      issues: trade.issues.length ? [...trade.issues] : undefined
+    };
+    if (trade.issues.length) {
+      issues.push(...trade.issues.map((text) => `${trade.id}: ${text}`));
+    }
+    if (trade.ts >= windowStart && trade.ts <= windowEnd) {
+      disposals.push(report);
+      totalsByAsset[trade.asset] += report.totalGainGBP;
+      for (const match of trade.matches) {
+        matchLines.push({ ...match, sellRef: trade.id, asset: trade.asset, ts: trade.ts });
+      }
+    }
+  }
+  const overallGain = Object.values(totalsByAsset).reduce((acc, v) => acc + v, 0);
+
+  return {
+    disposals,
+    matchLines,
+    pools: closingSnapshot,
+    totals: { overallGainGBP: overallGain, byAsset: totalsByAsset },
+    issues
+  };
+}
+
+type HmrcFinalOptions = HmrcComputationOptions;

--- a/svc-arbi-dash/app/src/lib/time.ts
+++ b/svc-arbi-dash/app/src/lib/time.ts
@@ -1,0 +1,60 @@
+import { DateTime, Duration } from 'luxon';
+
+export const LONDON_TZ = 'Europe/London';
+const DATE_FMT = 'dd LLL yyyy, HH:mm:ss';
+
+export function toLondonDateTime(ts: number): DateTime {
+  return DateTime.fromMillis(ts, { zone: LONDON_TZ });
+}
+
+export function formatDateTime(ts: number): string {
+  return toLondonDateTime(ts).toFormat(DATE_FMT);
+}
+
+export function formatDay(ts: number): string {
+  return toLondonDateTime(ts).toFormat('dd LLL yyyy');
+}
+
+export function ukDayKey(ts: number): string {
+  return toLondonDateTime(ts).toISODate();
+}
+
+export function parseUkDateTime(value: string): number {
+  const dt = DateTime.fromFormat(value, 'yyyy-LL-dd HH:mm', { zone: LONDON_TZ });
+  if (!dt.isValid) {
+    throw new Error('Invalid date');
+  }
+  return dt.toUTC().toMillis();
+}
+
+export function parseUkDate(value: string): number {
+  const dt = DateTime.fromFormat(value, 'yyyy-LL-dd', { zone: LONDON_TZ });
+  if (!dt.isValid) {
+    throw new Error('Invalid date');
+  }
+  return dt.toUTC().toMillis();
+}
+
+export function taxYearBounds(taxYear: string): { start: DateTime; end: DateTime } {
+  const [startYearStr, endSuffix] = taxYear.split('-');
+  if (!startYearStr || !endSuffix) {
+    throw new Error('Tax year format must be YYYY-YY');
+  }
+  const startYear = Number.parseInt(startYearStr, 10);
+  const endYear = Number.parseInt(startYearStr.slice(0, 2) + endSuffix, 10);
+  const start = DateTime.fromObject({ year: startYear, month: 4, day: 6 }, { zone: LONDON_TZ, hour: 0, minute: 0, second: 0 });
+  const end = DateTime.fromObject({ year: endYear, month: 4, day: 5, hour: 23, minute: 59, second: 59, millisecond: 999 }, { zone: LONDON_TZ });
+  return { start, end };
+}
+
+export function addMinutes(ts: number, minutes: number): number {
+  return toLondonDateTime(ts).plus({ minutes }).toMillis();
+}
+
+export function minutesBetween(a: number, b: number): number {
+  return Math.abs(Duration.fromMillis(b - a).as('minutes'));
+}
+
+export function withinLastMinutes(sampleTs: number, nowTs: number, minutes: number): boolean {
+  return nowTs - sampleTs <= minutes * 60 * 1000;
+}

--- a/svc-arbi-dash/app/src/lib/types.ts
+++ b/svc-arbi-dash/app/src/lib/types.ts
@@ -1,0 +1,128 @@
+export type AssetSymbol = 'ETH' | 'BTC' | 'USDT';
+
+export type AssetSnapshot = {
+  lunoBestBidZAR: number | null;
+  lunoBestAskZAR: number | null;
+  krakenBidGBP: number | null;
+  krakenAskGBP: number | null;
+  krakenBidZAR: number | null;
+  krakenAskZAR: number | null;
+  arb_buyKraken_sellLuno_pct: number | null;
+  arb_buyLuno_sellKraken_pct: number | null;
+};
+
+export type Cycle = {
+  trade: AssetSymbol;
+  via: AssetSymbol;
+  pct: number | null;
+};
+
+export type Sample = {
+  ts: number;
+  fx_gbp_zar: number;
+  ETH: AssetSnapshot;
+  BTC: AssetSnapshot;
+  USDT: AssetSnapshot;
+  cycles_from_Luno_ZAR: Cycle[];
+  cycles_from_Kraken_GBP: Cycle[];
+};
+
+export type Page = {
+  count: number;
+  nextCursor: string | null;
+  samples: Sample[];
+};
+
+export type Money = {
+  amount: number;
+  currency: 'GBP' | 'ZAR' | 'ASSET' | 'USD';
+};
+
+export type TradeSide = 'BUY' | 'SELL';
+
+export type TradeVenue = 'LUNO' | 'KRAKEN' | 'OTHER' | undefined;
+
+export type Trade = {
+  id: string;
+  ts: number;
+  asset: AssetSymbol;
+  venue?: TradeVenue;
+  side: TradeSide;
+  quantity: number;
+  priceGBP?: number;
+  priceZAR?: number;
+  fx_gbp_zar?: number;
+  fee?: Money;
+  notes?: string;
+  derived?: {
+    perUnitGBP: number;
+    gbpProceedsOrCost: number;
+    feeGBP?: number;
+    fxSource?: 'USER' | 'FRANKFURTER' | 'NONE';
+  };
+  locked?: boolean;
+};
+
+export type TradeFilters = {
+  asset?: AssetSymbol;
+  side?: TradeSide;
+  from?: number;
+  to?: number;
+};
+
+export type TradeListResponse = {
+  count: number;
+  nextCursor: string | null;
+  trades: Trade[];
+};
+
+export type TaxYearSummary = {
+  taxYear: string;
+  totals: {
+    overallGainGBP: number;
+    byAsset: Record<AssetSymbol, number>;
+  };
+  pools: Record<AssetSymbol, { totalQty: number; totalCostGBP: number; avgCostGBP: number }>;
+  disposals: DisposalReport[];
+  matchLines: FlatMatchLine[];
+  issues: string[];
+};
+
+export type MatchRule = 'SAME_DAY' | 'WITHIN_30_DAYS' | 'SECTION_104';
+
+export type MatchLine = {
+  rule: MatchRule;
+  buyRef?: string;
+  matchedQty: number;
+  proceedsGBP: number;
+  allowableCostGBP: number;
+  gainGBP: number;
+};
+
+export type FlatMatchLine = MatchLine & {
+  sellRef: string;
+  asset: AssetSymbol;
+  ts: number;
+};
+
+export type DisposalReport = {
+  sellRef: string;
+  ts: number;
+  asset: AssetSymbol;
+  quantity: number;
+  grossProceedsGBP: number;
+  disposalFeesGBP: number;
+  netProceedsGBP: number;
+  matches: MatchLine[];
+  totalGainGBP: number;
+  issues?: string[];
+};
+
+export type TaxPreviewRequest = {
+  from: string;
+  to: string;
+};
+
+export type TaxSummaryRequest = {
+  taxYear: string;
+};

--- a/svc-arbi-dash/app/src/main.tsx
+++ b/svc-arbi-dash/app/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/svc-arbi-dash/app/src/styles/index.css
+++ b/svc-arbi-dash/app/src/styles/index.css
@@ -1,0 +1,29 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+}
+
+a {
+  @apply text-sky-400 hover:text-sky-300;
+}
+
+input,
+select,
+textarea {
+  @apply bg-panel-subtle text-slate-100 border border-slate-700 rounded px-3 py-2 focus:outline-none focus:ring focus:ring-sky-500/50;
+}
+
+button {
+  @apply rounded px-3 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-60 disabled:cursor-not-allowed;
+}
+
+.card {
+  @apply bg-panel-subtle border border-slate-800 rounded-xl shadow-sm shadow-black/40;
+}

--- a/svc-arbi-dash/app/src/vite-env.d.ts
+++ b/svc-arbi-dash/app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/svc-arbi-dash/app/tailwind.config.js
+++ b/svc-arbi-dash/app/tailwind.config.js
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        panel: {
+          DEFAULT: '#0f172a',
+          subtle: '#1e293b'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/svc-arbi-dash/app/vite.config.ts
+++ b/svc-arbi-dash/app/vite.config.ts
@@ -1,7 +1,12 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  root: rootDir,
   base: '/dash/',
   plugins: [react()],
   build: {

--- a/svc-arbi-dash/app/vite.config.ts
+++ b/svc-arbi-dash/app/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/dash/',
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/app.js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name][extname]'
+      }
+    }
+  }
+});

--- a/svc-arbi-dash/package.json
+++ b/svc-arbi-dash/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "svc-arbi-dash",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "vite build --config app/vite.config.ts && wrangler build",
+    "deploy": "wrangler deploy",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "luxon": "^3.4.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "uplot": "^1.6.24"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240605.0",
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.11.0",
+    "@typescript-eslint/parser": "^7.11.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.34.3",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11",
+    "vitest": "^1.5.2",
+    "wrangler": "^3.52.0",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/svc-arbi-dash/tests/calc.spec.ts
+++ b/svc-arbi-dash/tests/calc.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  effectiveArbPercentage,
+  slippageDeduction,
+  withdrawalAmortizationPct,
+  percentageDifference
+} from '../app/src/lib/calc';
+
+describe('calc utilities', () => {
+  it('computes effective arbitrage with fees and slippage', () => {
+    const effective = effectiveArbPercentage({
+      nominalPct: 5,
+      legs: [
+        { feePct: 0.6, slippagePct: 0.1 },
+        { feePct: 0.4, slippagePct: 0.1 }
+      ],
+      withdrawalPct: 0.5
+    });
+    expect(effective).toBeCloseTo(3.4, 5);
+  });
+
+  it('aggregates slippage deduction', () => {
+    const total = slippageDeduction([
+      { slippagePct: 0.1 },
+      { slippagePct: 0.2 }
+    ]);
+    expect(total).toBeCloseTo(0.3, 5);
+  });
+
+  it('computes withdrawal amortization percentage', () => {
+    const pct = withdrawalAmortizationPct(0.0002, 2000, 10000);
+    expect(pct).toBeCloseTo(0.004, 6);
+  });
+
+  it('computes percentage differences with guard', () => {
+    const diff = percentageDifference(10, 12);
+    expect(diff.absolute).toBe(2);
+    expect(diff.relativePct).toBeCloseTo(20, 5);
+    expect(diff.percentagePoints).toBe(2);
+    const diffZero = percentageDifference(0, 5);
+    expect(diffZero.relativePct).toBeNull();
+  });
+});

--- a/svc-arbi-dash/tests/hmrc.spec.ts
+++ b/svc-arbi-dash/tests/hmrc.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { DateTime } from 'luxon';
+import { computeHmrc } from '../app/src/lib/hmrc';
+import { Trade } from '../app/src/lib/types';
+
+function tradeFactory(options: {
+  id: string;
+  ts: DateTime;
+  asset: 'ETH' | 'BTC' | 'USDT';
+  side: 'BUY' | 'SELL';
+  quantity: number;
+  priceGBP: number;
+  feeGBP?: number;
+}): Trade {
+  const tsMillis = options.ts.toMillis();
+  const proceeds = options.priceGBP * options.quantity;
+  return {
+    id: options.id,
+    ts: tsMillis,
+    asset: options.asset,
+    side: options.side,
+    quantity: options.quantity,
+    priceGBP: options.priceGBP,
+    priceZAR: undefined,
+    fx_gbp_zar: undefined,
+    fee: options.feeGBP ? { amount: options.feeGBP, currency: 'GBP' } : undefined,
+    derived: {
+      perUnitGBP: options.priceGBP,
+      gbpProceedsOrCost: proceeds,
+      feeGBP: options.feeGBP,
+      fxSource: 'USER'
+    }
+  };
+}
+
+describe('HMRC computation', () => {
+  it('prioritises same-day matches', () => {
+    const buy = tradeFactory({
+      id: 'b1',
+      ts: DateTime.fromISO('2024-05-01T10:00', { zone: 'Europe/London' }),
+      asset: 'ETH',
+      side: 'BUY',
+      quantity: 1,
+      priceGBP: 1000
+    });
+    const sell = tradeFactory({
+      id: 's1',
+      ts: DateTime.fromISO('2024-05-01T18:00', { zone: 'Europe/London' }),
+      asset: 'ETH',
+      side: 'SELL',
+      quantity: 1,
+      priceGBP: 1200
+    });
+    const report = computeHmrc([buy, sell], {
+      windowStart: buy.ts - 1,
+      windowEnd: sell.ts + 1,
+      poolSnapshotAt: sell.ts
+    });
+    expect(report.disposals).toHaveLength(1);
+    expect(report.disposals[0].matches[0].rule).toBe('SAME_DAY');
+    expect(report.disposals[0].matches[0].gainGBP).toBeCloseTo(200, 5);
+  });
+
+  it('matches within 30 days for future buys', () => {
+    const sell = tradeFactory({
+      id: 's1',
+      ts: DateTime.fromISO('2024-06-01T10:00', { zone: 'Europe/London' }),
+      asset: 'BTC',
+      side: 'SELL',
+      quantity: 0.5,
+      priceGBP: 20000
+    });
+    const buy = tradeFactory({
+      id: 'b1',
+      ts: DateTime.fromISO('2024-06-20T12:00', { zone: 'Europe/London' }),
+      asset: 'BTC',
+      side: 'BUY',
+      quantity: 0.5,
+      priceGBP: 18000
+    });
+    const report = computeHmrc([sell, buy], {
+      windowStart: sell.ts - 1,
+      windowEnd: buy.ts + 1,
+      poolSnapshotAt: buy.ts
+    });
+    expect(report.disposals[0].matches[0].rule).toBe('WITHIN_30_DAYS');
+    expect(report.disposals[0].matches[0].matchedQty).toBeCloseTo(0.5, 6);
+  });
+
+  it('falls back to Section 104 pool', () => {
+    const buy1 = tradeFactory({
+      id: 'b1',
+      ts: DateTime.fromISO('2023-01-01T09:00', { zone: 'Europe/London' }),
+      asset: 'USDT',
+      side: 'BUY',
+      quantity: 1000,
+      priceGBP: 0.8
+    });
+    const buy2 = tradeFactory({
+      id: 'b2',
+      ts: DateTime.fromISO('2023-03-01T09:00', { zone: 'Europe/London' }),
+      asset: 'USDT',
+      side: 'BUY',
+      quantity: 1000,
+      priceGBP: 0.82
+    });
+    const sell = tradeFactory({
+      id: 's1',
+      ts: DateTime.fromISO('2024-01-01T09:00', { zone: 'Europe/London' }),
+      asset: 'USDT',
+      side: 'SELL',
+      quantity: 1500,
+      priceGBP: 0.9
+    });
+    const report = computeHmrc([buy1, buy2, sell], {
+      windowStart: buy1.ts,
+      windowEnd: sell.ts,
+      poolSnapshotAt: sell.ts
+    });
+    expect(report.disposals[0].matches[0].rule).toBe('SECTION_104');
+    const allowable = report.disposals[0].matches[0].allowableCostGBP;
+    expect(allowable).toBeGreaterThan(0);
+    expect(report.pools.USDT.totalQty).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/svc-arbi-dash/tsconfig.json
+++ b/svc-arbi-dash/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "jsx": "react-jsx",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": [
+    "worker/src/**/*",
+    "app/src/**/*",
+    "app/vite.config.ts",
+    "app/tailwind.config.js",
+    "tests/**/*",
+    "wrangler.json"
+  ],
+  "exclude": ["node_modules", "app/dist"]
+}

--- a/svc-arbi-dash/tsconfig.json
+++ b/svc-arbi-dash/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "worker/src/**/*",
+    "src/**/*",
     "app/src/**/*",
     "app/vite.config.ts",
     "app/tailwind.config.js",

--- a/svc-arbi-dash/worker/src/index.ts
+++ b/svc-arbi-dash/worker/src/index.ts
@@ -1,0 +1,426 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DateTime } from 'luxon';
+import { computeHmrc } from '../../app/src/lib/hmrc';
+import { taxYearBounds, parseUkDate } from '../../app/src/lib/time';
+import { Trade, TradeListResponse, TaxYearSummary } from '../../app/src/lib/types';
+
+interface Env {
+  AUTH_TOKEN: string;
+  TRADE_STORE: DurableObjectNamespace;
+  TRADE_LEDGER: DurableObjectNamespace;
+}
+
+type EnvWithAssets = Env & {
+  ASSETS?: { fetch(request: Request): Promise<Response> };
+};
+
+const SECURITY_HEADERS: HeadersInit = {
+  'Cache-Control': 'no-store',
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff'
+};
+
+function withSecurityHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+async function proxyToAsset(request: Request, env: EnvWithAssets, url: URL): Promise<Response> {
+  const assets = env.ASSETS;
+  if (!assets) {
+    return new Response('Assets binding missing', { status: 500 });
+  }
+  const stripped = url.pathname === '/dash' ? '/index.html' : url.pathname.replace(/^\/dash/, '') || '/index.html';
+  const assetUrl = new URL(stripped.startsWith('/') ? stripped : `/${stripped}`, url.origin);
+  const assetRequest = new Request(assetUrl.toString(), {
+    method: request.method,
+    headers: request.headers
+  });
+  const assetResponse = await assets.fetch(assetRequest);
+  return withSecurityHeaders(assetResponse);
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    const auth = url.searchParams.get('auth');
+    if (!auth || auth !== env.AUTH_TOKEN) {
+      return new Response('Not found', { status: 404 });
+    }
+    url.searchParams.delete('auth');
+
+    if (url.pathname === '/dash' || url.pathname.startsWith('/dash/')) {
+      return proxyToAsset(request, env as EnvWithAssets, url);
+    }
+
+    if (url.pathname === '/data') {
+      const id = env.TRADE_STORE.idFromName('arbi-store');
+      const stub = env.TRADE_STORE.get(id);
+      const proxyUrl = new URL(`https://do${url.pathname}${url.search}`);
+      const response = await stub.fetch(new Request(proxyUrl.toString(), request));
+      return withSecurityHeaders(response);
+    }
+
+    if (url.pathname.startsWith('/trades') || url.pathname.startsWith('/tax/')) {
+      const id = env.TRADE_LEDGER.idFromName('ledger');
+      const stub = env.TRADE_LEDGER.get(id);
+      const target = new URL(`https://ledger${url.pathname}${url.search}`);
+      const forwarded = new Request(target.toString(), request);
+      const response = await stub.fetch(forwarded);
+      return withSecurityHeaders(response);
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+};
+
+function padTs(ts: number): string {
+  return ts.toString().padStart(13, '0');
+}
+
+async function responseJson(data: unknown, status = 200): Promise<Response> {
+  return withSecurityHeaders(
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  );
+}
+
+async function parseJson<T>(request: Request): Promise<T> {
+  return (await request.json()) as T;
+}
+
+function matchesFilters(trade: Trade, filters: { asset?: string; side?: string; from?: number; to?: number }): boolean {
+  if (filters.asset && trade.asset !== filters.asset) {
+    return false;
+  }
+  if (filters.side && trade.side !== filters.side) {
+    return false;
+  }
+  if (filters.from && trade.ts < filters.from) {
+    return false;
+  }
+  if (filters.to && trade.ts > filters.to) {
+    return false;
+  }
+  return true;
+}
+
+function computeTaxYearLabel(trade: Trade): string {
+  const dt = DateTime.fromMillis(trade.ts, { zone: 'Europe/London' });
+  const year = dt.month >= 4 ? dt.year : dt.year - 1;
+  const suffix = String((year + 1) % 100).padStart(2, '0');
+  return `${year}-${suffix}`;
+}
+
+async function fetchFxForDate(date: string): Promise<number> {
+  const url = `https://api.frankfurter.app/${date}?from=GBP&to=ZAR`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch Frankfurter FX');
+  }
+  const data = (await res.json()) as { rates: Record<string, number> };
+  return data.rates.ZAR;
+}
+
+async function convertFeeToGBP(fee: Trade['fee'], perUnitGBP: number, fx: number | undefined, ts: number): Promise<number | undefined> {
+  if (!fee) {
+    return undefined;
+  }
+  if (fee.currency === 'GBP') {
+    return fee.amount;
+  }
+  if (fee.currency === 'ASSET') {
+    return fee.amount * perUnitGBP;
+  }
+  if (fee.currency === 'ZAR') {
+    if (!fx) {
+      const date = DateTime.fromMillis(ts, { zone: 'Europe/London' }).toFormat('yyyy-LL-dd');
+      const rate = await fetchFxForDate(date);
+      return fee.amount / rate;
+    }
+    return fee.amount / fx;
+  }
+  return undefined;
+}
+
+async function resolveDerived(trade: Trade): Promise<Trade> {
+  if (!trade.priceGBP && (!trade.priceZAR || !trade.fx_gbp_zar)) {
+    throw new Error('GBP valuation required');
+  }
+  let fxSource: 'USER' | 'FRANKFURTER' | 'NONE' = 'NONE';
+  let fx = trade.fx_gbp_zar;
+  if (!trade.priceGBP && trade.priceZAR && !fx) {
+    const date = DateTime.fromMillis(trade.ts, { zone: 'Europe/London' }).toFormat('yyyy-LL-dd');
+    fx = await fetchFxForDate(date);
+    trade.fx_gbp_zar = fx;
+    fxSource = 'FRANKFURTER';
+  } else if (trade.fx_gbp_zar) {
+    fxSource = 'USER';
+  }
+  const perUnitGBP = trade.priceGBP ?? (trade.priceZAR! / trade.fx_gbp_zar!);
+  const proceeds = perUnitGBP * trade.quantity;
+  const feeGBP = await convertFeeToGBP(trade.fee, perUnitGBP, trade.fx_gbp_zar, trade.ts);
+  return {
+    ...trade,
+    derived: {
+      perUnitGBP,
+      gbpProceedsOrCost: proceeds,
+      feeGBP,
+      fxSource
+    }
+  };
+}
+
+export class TradeLedger {
+  private state: DurableObjectState;
+  private storage: DurableObjectStorage;
+
+  constructor(state: DurableObjectState, _env: Env) {
+    this.state = state;
+    this.storage = state.storage;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/trades/lock') {
+      const body = await parseJson<{ ids: string[] }>(request);
+      await Promise.all(body.ids.map((id) => this.lockTrade(id)));
+      return responseJson({ ok: true });
+    }
+
+    if (url.pathname === '/trades' && request.method === 'GET') {
+      return this.handleList(url);
+    }
+
+    if (url.pathname === '/trades' && request.method === 'POST') {
+      const payload = await parseJson<Partial<Trade>>(request);
+      return this.handleCreate(payload);
+    }
+
+    if (url.pathname.startsWith('/trades/') && request.method === 'GET') {
+      const id = url.pathname.split('/')[2];
+      const trade = await this.storage.get<Trade>(`trade:${id}`);
+      if (!trade) {
+        return new Response('Not found', { status: 404 });
+      }
+      return responseJson(trade);
+    }
+
+    if (url.pathname.startsWith('/trades/') && request.method === 'PUT') {
+      const id = url.pathname.split('/')[2];
+      const payload = await parseJson<Partial<Trade>>(request);
+      payload.id = id;
+      return this.handleUpdate(payload);
+    }
+
+    if (url.pathname.startsWith('/trades/') && request.method === 'DELETE') {
+      const id = url.pathname.split('/')[2];
+      await this.deleteTrade(id);
+      return responseJson({ ok: true });
+    }
+
+    if (url.pathname === '/tax/summary' && request.method === 'GET') {
+      const taxYear = url.searchParams.get('taxYear');
+      if (!taxYear) {
+        return new Response('taxYear required', { status: 400 });
+      }
+      const summary = await this.computeTaxYear(taxYear);
+      return responseJson(summary);
+    }
+
+    if (url.pathname === '/tax/preview' && request.method === 'GET') {
+      const from = url.searchParams.get('from');
+      const to = url.searchParams.get('to');
+      if (!from || !to) {
+        return new Response('from and to required', { status: 400 });
+      }
+      const fromTs = parseUkDate(from);
+      const toTs = parseUkDate(to) + 24 * 60 * 60 * 1000 - 1;
+      const summary = await this.computeWindow(fromTs, toTs);
+      return responseJson(summary);
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+
+  private async handleList(url: URL): Promise<Response> {
+    const limit = Math.min(Number(url.searchParams.get('limit') ?? '100'), 500);
+    const cursor = url.searchParams.get('cursor');
+    const filters = {
+      asset: url.searchParams.get('asset') ?? undefined,
+      side: url.searchParams.get('side') ?? undefined,
+      from: url.searchParams.get('from') ? Number(url.searchParams.get('from')) : undefined,
+      to: url.searchParams.get('to') ? Number(url.searchParams.get('to')) : undefined
+    };
+    const { trades, nextCursor } = await this.listTrades(filters, limit, cursor ?? undefined);
+    const response: TradeListResponse = {
+      count: trades.length,
+      trades,
+      nextCursor: nextCursor ?? null
+    };
+    return responseJson(response);
+  }
+
+  private async handleCreate(payload: Partial<Trade>): Promise<Response> {
+    if (!payload.ts || !payload.asset || !payload.side || !payload.quantity) {
+      return new Response('Missing fields', { status: 400 });
+    }
+    const id = `${payload.ts}-${crypto.randomUUID().slice(0, 8)}`;
+    const trade: Trade = await resolveDerived({
+      ...(payload as Trade),
+      id
+    });
+    await this.putTrade(trade);
+    return responseJson(trade, 201);
+  }
+
+  private async handleUpdate(payload: Partial<Trade>): Promise<Response> {
+    if (!payload.id) {
+      return new Response('id required', { status: 400 });
+    }
+    const existing = await this.storage.get<Trade>(`trade:${payload.id}`);
+    if (!existing) {
+      return new Response('Not found', { status: 404 });
+    }
+    if (existing.locked) {
+      return new Response('Trade locked', { status: 400 });
+    }
+    const updated = await resolveDerived({ ...existing, ...payload } as Trade);
+    await this.putTrade(updated, existing);
+    return responseJson(updated);
+  }
+
+  private async lockTrade(id: string): Promise<void> {
+    const trade = await this.storage.get<Trade>(`trade:${id}`);
+    if (trade) {
+      trade.locked = true;
+      await this.putTrade(trade, trade);
+    }
+  }
+
+  private async deleteTrade(id: string): Promise<void> {
+    const trade = await this.storage.get<Trade>(`trade:${id}`);
+    if (!trade) {
+      return;
+    }
+    if (trade.locked) {
+      throw new Error('Trade locked');
+    }
+    await this.storage.delete(`trade:${id}`);
+    await this.storage.delete(`by-asset:${trade.asset}:${padTs(trade.ts)}:${trade.id}`);
+    await this.storage.delete(`by-taxyear:${computeTaxYearLabel(trade)}:${padTs(trade.ts)}:${trade.id}`);
+  }
+
+  private async putTrade(trade: Trade, previous?: Trade): Promise<void> {
+    if (!trade.id) {
+      throw new Error('Trade id missing');
+    }
+    if (previous && previous.id !== trade.id) {
+      await this.deleteTrade(previous.id);
+    }
+    await this.storage.put(`trade:${trade.id}`, trade);
+    await this.storage.put(`by-asset:${trade.asset}:${padTs(trade.ts)}:${trade.id}`, true);
+    await this.storage.put(`by-taxyear:${computeTaxYearLabel(trade)}:${padTs(trade.ts)}:${trade.id}`, true);
+  }
+
+  private async listTrades(
+    filters: { asset?: string; side?: string; from?: number; to?: number },
+    limit: number,
+    cursor?: string
+  ): Promise<{ trades: Trade[]; nextCursor?: string }> {
+    const result: Trade[] = [];
+    let startAfter = cursor ? `trade:${cursor}` : undefined;
+    let lastKey: string | undefined;
+    const pageSize = limit * 3;
+    while (result.length < limit) {
+      const page = await this.storage.list<Trade>({ prefix: 'trade:', reverse: true, startAfter, limit: pageSize });
+      if (page.size === 0) {
+        break;
+      }
+      for (const [key, trade] of page) {
+        lastKey = key;
+        startAfter = key;
+        if (matchesFilters(trade, filters)) {
+          result.push(trade);
+          if (result.length === limit) {
+            break;
+          }
+        }
+      }
+      if (page.size < pageSize) {
+        break;
+      }
+    }
+    const nextCursor = result.length === limit && lastKey ? lastKey.replace('trade:', '') : undefined;
+    return { trades: result, nextCursor };
+  }
+
+  private async loadAllTrades(): Promise<Trade[]> {
+    const trades: Trade[] = [];
+    let cursor: string | undefined;
+    const pageSize = 256;
+    while (true) {
+      const page = await this.storage.list<Trade>({ prefix: 'trade:', limit: pageSize, startAfter: cursor });
+      if (page.size === 0) {
+        break;
+      }
+      for (const [key, value] of page) {
+        trades.push(value);
+        cursor = key;
+      }
+      if (page.size < pageSize) {
+        break;
+      }
+    }
+    trades.sort((a, b) => a.ts - b.ts);
+    return trades;
+  }
+
+  private async computeTaxYear(taxYear: string): Promise<TaxYearSummary> {
+    const { start, end } = taxYearBounds(taxYear);
+    const allTrades = await this.loadAllTrades();
+    const windowStart = start.toMillis();
+    const windowEnd = end.toMillis();
+    const trades = allTrades.filter((trade) => trade.ts <= windowEnd + 30 * 24 * 60 * 60 * 1000);
+    const computation = computeHmrc(trades, {
+      windowStart,
+      windowEnd,
+      poolSnapshotAt: windowEnd
+    });
+    return {
+      taxYear,
+      totals: computation.totals,
+      pools: computation.pools,
+      disposals: computation.disposals,
+      matchLines: computation.matchLines,
+      issues: computation.issues
+    };
+  }
+
+  private async computeWindow(from: number, to: number): Promise<TaxYearSummary> {
+    const allTrades = await this.loadAllTrades();
+    const trades = allTrades.filter((trade) => trade.ts >= from - 30 * 24 * 60 * 60 * 1000 && trade.ts <= to + 30 * 24 * 60 * 60 * 1000);
+    const computation = computeHmrc(trades, {
+      windowStart: from,
+      windowEnd: to,
+      poolSnapshotAt: to
+    });
+    return {
+      taxYear: `${DateTime.fromMillis(from).toFormat('yyyy')} window`,
+      totals: computation.totals,
+      pools: computation.pools,
+      disposals: computation.disposals,
+      matchLines: computation.matchLines,
+      issues: computation.issues
+    };
+  }
+}

--- a/svc-arbi-dash/wrangler.json
+++ b/svc-arbi-dash/wrangler.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "svc-arbi-dash",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-09-21",
+  "observability": { "enabled": true },
+  "durable_objects": {
+    "bindings": [
+      { "name": "TRADE_STORE", "class_name": "TradeStore", "script_name": "svc-arbi-ingestor" },
+      { "name": "TRADE_LEDGER", "class_name": "TradeLedger" }
+    ]
+  },
+  "migrations": [
+    { "tag": "trade-ledger-v1", "new_sqlite_classes": ["TradeLedger"] }
+  ],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "app/dist"
+  }
+}

--- a/svc-arbi-dash/wrangler.json
+++ b/svc-arbi-dash/wrangler.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "svc-arbi-dash",
-  "main": "src/index.ts",
+  "main": "worker/src/index.ts",
   "compatibility_date": "2025-09-21",
   "observability": { "enabled": true },
   "durable_objects": {


### PR DESCRIPTION
## Summary
- add Cloudflare Worker router with TradeLedger durable object and Frankfurter-backed GBP valuation
- implement Vite + Tailwind React dashboard with charts, tables, calculators, settings drawer, trades, and tax reports
- share calc and HMRC utilities with Vitest coverage for effective arbitrage math and share-matching rules

## Testing
- npm test *(fails: vitest not found because npm install was blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d1afe0742c8329baf315912bd44f62