### PR TITLE
Point wrangler entry to worker implementation

### DIFF
--- a/svc-arbi-dash/tsconfig.json
+++ b/svc-arbi-dash/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "worker/src/**/*",
+    "src/**/*",
     "app/src/**/*",
     "app/vite.config.ts",
     "app/tailwind.config.js",

--- a/svc-arbi-dash/wrangler.json
+++ b/svc-arbi-dash/wrangler.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "svc-arbi-dash",
-  "main": "src/index.ts",
+  "main": "worker/src/index.ts",
   "compatibility_date": "2025-09-21",
   "observability": { "enabled": true },
   "durable_objects": {


### PR DESCRIPTION
## Summary
- remove the unused root-level `src/index.ts` shim that previously re-exported the worker
- point the Wrangler `main` field at `worker/src/index.ts`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1bc6b48ac832999fed29a2181faf4