### PR TITLE
Fix Vite root resolution for dashboard app

### DIFF
--- a/svc-arbi-dash/app/vite.config.ts
+++ b/svc-arbi-dash/app/vite.config.ts
@@ -1,7 +1,12 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  root: rootDir,
   base: '/dash/',
   plugins: [react()],
   build: {


### PR DESCRIPTION
## Summary
- configure Vite to treat the /app directory as its project root for index resolution
- derive the root directory from the config file location so the ESM setup works without __dirname

## Testing
- npm run build *(fails: vite binary unavailable before dependency install)*
- npm install *(fails: 403 fetching @cloudflare/workers-types in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c15dbeb08329bddb891de18a6479